### PR TITLE
add more rows for tag fetching

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -424,7 +424,7 @@ public class CassandraDatastore implements Datastore {
     @Override
     public TagSet queryMetricTags(DatastoreMetricQuery query) {
         TagSetImpl tagSet = new TagSetImpl();
-        Collection<DataPointsRowKey> rowKeys = getKeysForQueryIterator(query, 150);
+        Collection<DataPointsRowKey> rowKeys = getKeysForQueryIterator(query, 1000);
 
         MemoryMonitor mm = new MemoryMonitor(20);
         for (DataPointsRowKey key : rowKeys) {


### PR DESCRIPTION
we set to what we expect as number of aws accounts and double it (...
times two, because of multiple timestamps in the result)