### PR TITLE
Adds Elasticache smart client and switches from Redis to it

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -97,4 +97,3 @@ kairosdb.datastore.cassandra.cache.elasticache.writer_thread_idle_timeout_second
 kairosdb.datastore.cassandra.cache.elasticache.ttl_in_seconds=691200
 kairosdb.datastore.cassandra.cache.elasticache.max_queue_size=20000
 kairosdb.datastore.cassandra.cache.elasticache.operation_timeout_in_millis=100
-kairosdb.datastore.cassandra.cache.elasticache.connection_pool_size=50

--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -89,11 +89,12 @@ kairosdb.datastore.cassandra.datapoint_ttl=8070400
 # kairosdb.datastore.cassandra.cache.tag_value.size=1024
 
 #===============================================================================
-kairosdb.datastore.cassandra.cache.redis.hostname=localhost
-kairosdb.datastore.cassandra.cache.redis.port=6379
-kairosdb.datastore.cassandra.cache.redis.connection_timeout_in_millis=500
-kairosdb.datastore.cassandra.cache.redis.socket_timeout_in_millis=50
-kairosdb.datastore.cassandra.cache.redis.writer_threads=20
-kairosdb.datastore.cassandra.cache.redis.writer_thread_idle_timeout_seconds=300
-kairosdb.datastore.cassandra.cache.redis.ttl_in_seconds=691200
-kairosdb.datastore.cassandra.cache.redis.max_queue_size=20000
+kairosdb.datastore.cassandra.cache.elasticache.hostname=localhost
+kairosdb.datastore.cassandra.cache.elasticache.port=11211
+kairosdb.datastore.cassandra.cache.elasticache.connection_timeout_in_millis=500
+kairosdb.datastore.cassandra.cache.elasticache.writer_threads=20
+kairosdb.datastore.cassandra.cache.elasticache.writer_thread_idle_timeout_seconds=300
+kairosdb.datastore.cassandra.cache.elasticache.ttl_in_seconds=691200
+kairosdb.datastore.cassandra.cache.elasticache.max_queue_size=20000
+kairosdb.datastore.cassandra.cache.elasticache.operation_timeout_in_millis=100
+kairosdb.datastore.cassandra.cache.elasticache.connection_pool_size=50

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
             <version>2.9.0</version>
         </dependency>
         <dependency>
+            <groupId>com.googlecode.xmemcached</groupId>
+            <artifactId>xmemcached</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>zero-allocation-hashing</artifactId>
             <version>0.8</version>

--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/CachingModule.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/CachingModule.java
@@ -1,9 +1,7 @@
 package org.kairosdb.datastore.cassandra.cache;
 
 import com.google.inject.AbstractModule;
-import org.kairosdb.datastore.cassandra.cache.persistence.GeneralHashCacheStore;
-import org.kairosdb.datastore.cassandra.cache.persistence.RedisConfiguration;
-import org.kairosdb.datastore.cassandra.cache.persistence.RedisWriteBackReadThroughCacheStore;
+import org.kairosdb.datastore.cassandra.cache.persistence.*;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.name.Names.named;
@@ -15,11 +13,11 @@ import static org.kairosdb.datastore.cassandra.cache.DefaultTagValueCache.TAG_VA
 public class CachingModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(RedisConfiguration.class).in(SINGLETON);
+        bind(ElastiCacheConfiguration.class).in(SINGLETON);
 
         bind(RowKeyCacheConfiguration.class).in(SINGLETON);
         bind(GeneralHashCacheStore.class).annotatedWith(named(ROW_KEY_CACHE))
-                .to(RedisWriteBackReadThroughCacheStore.class).in(SINGLETON);
+                .to(ElastiCacheWriteBackReadThroughCacheStore.class).in(SINGLETON);
         bind(RowKeyCache.class).to(DefaultRowKeyCache.class).in(SINGLETON);
 
         bindStringCache(METRIC_NAME_CACHE, MetricNameCacheConfiguration.class, DefaultMetricNameCache.class);
@@ -31,7 +29,7 @@ public class CachingModule extends AbstractModule {
                                  final Class<? extends StringKeyCache> clazz) {
         bind(configClass).in(SINGLETON);
         bind(GeneralHashCacheStore.class).annotatedWith(named(cacheName))
-                .to(RedisWriteBackReadThroughCacheStore.class).in(SINGLETON);
+                .to(ElastiCacheWriteBackReadThroughCacheStore.class).in(SINGLETON);
         bind(StringKeyCache.class).annotatedWith(named(cacheName)).to(clazz).in(SINGLETON);
 
     }

--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheConfiguration.java
@@ -1,0 +1,91 @@
+package org.kairosdb.datastore.cassandra.cache.persistence;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+public class ElastiCacheConfiguration {
+    private static final String PREFIX = "kairosdb.datastore.cassandra.cache.elasticache.";
+
+    private static final String HOSTNAME = PREFIX + "hostname";
+    private static final String PORT = PREFIX + "port";
+    private static final String CONNECTION_TIMEOUT_IN_MILLIS = PREFIX + "connection_timeout_in_millis";
+    private static final String WRITER_THREADS = PREFIX + "writer_threads";
+    private static final String WRITER_THREAD_IDLE_TIMEOUT_SECONDS = PREFIX + "writer_thread_idle_timeout_seconds";
+    private static final String TTL_IN_SECONDS = PREFIX + "ttl_in_seconds";
+    private static final String MAX_QUEUE_SIZE = PREFIX + "max_queue_size";
+    private static final String OPERATION_TIMEOUT_IN_MILLIS = PREFIX + "operation_timeout_in_millis";
+    private static final String CONNECTION_POOL_SIZE = PREFIX + "connection_pool_size";
+
+
+    @Inject(optional = true)
+    @Named(HOSTNAME)
+    private String hostName = "localhost";
+
+    @Inject(optional = true)
+    @Named(PORT)
+    private int port = 6379;
+
+    @Inject(optional = true)
+    @Named(CONNECTION_TIMEOUT_IN_MILLIS)
+    private int connectionTimeoutInMillis = 500;
+
+    @Inject(optional = true)
+    @Named(OPERATION_TIMEOUT_IN_MILLIS)
+    private int operationTimeoutInMillis = 500;
+
+    @Inject(optional = true)
+    @Named(WRITER_THREADS)
+    private int writerThreads = 20;
+
+    @Inject(optional = true)
+    @Named(WRITER_THREAD_IDLE_TIMEOUT_SECONDS)
+    private int workerThreadIdleTimeoutSeconds = 300;
+
+    @Inject(optional = true)
+    @Named(CONNECTION_POOL_SIZE)
+    private int connectionPoolSize = 50;
+
+    @Inject(optional = true)
+    @Named(TTL_IN_SECONDS)
+    private int ttlInSeconds = 691_200; // 8 days default
+
+    @Inject(optional = true)
+    @Named(MAX_QUEUE_SIZE)
+    private int maxQueueSize = 20_000;
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public int getConnectionTimeoutInMillis() {
+        return connectionTimeoutInMillis;
+    }
+
+    public int getOperationTimeoutInMillis() {
+        return operationTimeoutInMillis;
+    }
+
+    public int getWriterThreads() {
+        return writerThreads;
+    }
+
+    public int getWorkerThreadIdleTimeoutSeconds() {
+        return workerThreadIdleTimeoutSeconds;
+    }
+
+    public int getTtlInSeconds() {
+        return ttlInSeconds;
+    }
+
+    public int getMaxQueueSize() {
+        return maxQueueSize;
+    }
+
+    public int getConnectionPoolSize() {
+        return connectionPoolSize;
+    }
+}

--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheConfiguration.java
@@ -14,7 +14,6 @@ public class ElastiCacheConfiguration {
     private static final String TTL_IN_SECONDS = PREFIX + "ttl_in_seconds";
     private static final String MAX_QUEUE_SIZE = PREFIX + "max_queue_size";
     private static final String OPERATION_TIMEOUT_IN_MILLIS = PREFIX + "operation_timeout_in_millis";
-    private static final String CONNECTION_POOL_SIZE = PREFIX + "connection_pool_size";
 
 
     @Inject(optional = true)
@@ -40,10 +39,6 @@ public class ElastiCacheConfiguration {
     @Inject(optional = true)
     @Named(WRITER_THREAD_IDLE_TIMEOUT_SECONDS)
     private int workerThreadIdleTimeoutSeconds = 300;
-
-    @Inject(optional = true)
-    @Named(CONNECTION_POOL_SIZE)
-    private int connectionPoolSize = 50;
 
     @Inject(optional = true)
     @Named(TTL_IN_SECONDS)
@@ -83,9 +78,5 @@ public class ElastiCacheConfiguration {
 
     public int getMaxQueueSize() {
         return maxQueueSize;
-    }
-
-    public int getConnectionPoolSize() {
-        return connectionPoolSize;
     }
 }

--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheWriteBackReadThroughCacheStore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheWriteBackReadThroughCacheStore.java
@@ -1,0 +1,83 @@
+package org.kairosdb.datastore.cassandra.cache.persistence;
+
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import net.rubyeye.xmemcached.aws.AWSElasticCacheClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.*;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.util.concurrent.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ElastiCacheWriteBackReadThroughCacheStore implements GeneralHashCacheStore {
+    private final Logger LOG = LoggerFactory.getLogger(ElastiCacheWriteBackReadThroughCacheStore.class);
+    private final ExecutorService executor;
+    private final int defaultTtlInSeconds;
+    private final AWSElasticCacheClient client;
+
+    @Inject
+    public ElastiCacheWriteBackReadThroughCacheStore(final ElastiCacheConfiguration config) throws IOException {
+        this.defaultTtlInSeconds = config.getTtlInSeconds();
+        this.executor = createExecutorService(config);
+        
+        this.client = new AWSElasticCacheClient(new InetSocketAddress(config.getHostName(), config.getPort()));
+        this.client.setConnectTimeout(config.getConnectionTimeoutInMillis());
+        this.client.setOpTimeout(config.getOperationTimeoutInMillis());
+        this.client.setConnectionPoolSize(config.getConnectionPoolSize());
+    }
+
+    private ExecutorService createExecutorService(final ElastiCacheConfiguration config) {
+        final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
+                config.getWriterThreads(),
+                config.getWriterThreads(),
+                config.getWorkerThreadIdleTimeoutSeconds(), TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(config.getMaxQueueSize()),
+                new ThreadFactoryBuilder().setNameFormat(ElastiCacheWriteBackReadThroughCacheStore.class.getSimpleName() +
+                        "-writer-thread-%d").build());
+        threadPoolExecutor.allowCoreThreadTimeOut(true);
+        return threadPoolExecutor;
+    }
+
+    @CheckForNull
+    @Override
+    public Object load(@Nonnull final BigInteger key) throws Exception {
+        checkNotNull(key, "cache key can't be null");
+        try {
+            return client.get(key.toString());
+        } catch (Exception e) {
+            LOG.error("failed to load cache value for key {}", key, e);
+            return null;
+        }
+    }
+
+    @Override
+    public void write(@Nonnull final BigInteger key, @Nonnull final Object value) {
+        checkNotNull(key, "cache key can't be null");
+        checkNotNull(value, "cache value can't be null");
+        executor.submit(() -> {
+            try {
+                client.set(key.toString(), defaultTtlInSeconds, value.toString());
+            } catch (Exception e) {
+                LOG.error("failed to write back cache value for key {}", key, e);
+            }
+        });
+    }
+
+    @Override
+    public void delete(@Nonnull final BigInteger key, @Nullable final Object value, @Nonnull final RemovalCause removalCause) {
+        checkNotNull(key, "cache key can't be null");
+        executor.submit(() -> {
+            try {
+                client.delete(key.toString());
+            } catch (Exception e) {
+                LOG.error("failed to delete cache key {}", key, e);
+            }
+        });
+    }
+}

--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheWriteBackReadThroughCacheStore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/persistence/ElastiCacheWriteBackReadThroughCacheStore.java
@@ -25,11 +25,11 @@ public class ElastiCacheWriteBackReadThroughCacheStore implements GeneralHashCac
     public ElastiCacheWriteBackReadThroughCacheStore(final ElastiCacheConfiguration config) throws IOException {
         this.defaultTtlInSeconds = config.getTtlInSeconds();
         this.executor = createExecutorService(config);
-        
+
         this.client = new AWSElasticCacheClient(new InetSocketAddress(config.getHostName(), config.getPort()));
         this.client.setConnectTimeout(config.getConnectionTimeoutInMillis());
         this.client.setOpTimeout(config.getOperationTimeoutInMillis());
-        this.client.setConnectionPoolSize(config.getConnectionPoolSize());
+        this.client.setConnectionPoolSize(config.getWriterThreads());
     }
 
     private ExecutorService createExecutorService(final ElastiCacheConfiguration config) {


### PR DESCRIPTION
More or less resembles Redis store.
I did not use exact Memcached client, but insted used "smarter" version of it tailored to AWS Elasticache. Should be easier to use with AWS Elasticache cluster