### PR TITLE
Add Lightstep bootstrapping and configuration

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -71,3 +71,8 @@ kairosdb.datastore.cassandra.datapoint_ttl=8070400
 # Cache file cleaning schedule. Uses Quartz Cron syntax
 kairosdb.query_cache.cache_file_cleaner_schedule=0 0 12 ? * * *
 
+# Lightstep:
+tracing.lightstep.access_token=
+tracing.lightstep.collector_host=
+tracing.lightstep.collector_port=443
+tracing.lightstep.collector_protocol=https

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,10 @@
         <assertj.version>2.3.0</assertj.version>
         <mockito.version>1.10.19</mockito.version>
         <json-path.version>2.0.0</json-path.version>
-	<skipTests>true</skipTests>
+        <skipTests>true</skipTests>
+        <jetty.alpnAgent.version>2.0.0</jetty.alpnAgent.version>
+        <jetty.alpnAgent.directory>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}</jetty.alpnAgent.directory>
+        <jetty.alpnAgent.name>jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.name>
         <argLine />
     </properties>
 
@@ -208,12 +211,22 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.11.1</version>
+            <version>0.12.15</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <version>1.4.0</version>
+            <version>1.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.14.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.14.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -315,6 +328,7 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -325,6 +339,26 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>get-jetty-alpn-agent</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>get</goal>
+                        </goals>
+                        <configuration>
+                            <groupId>org.mortbay.jetty.alpn</groupId>
+                            <artifactId>jetty-alpn-agent</artifactId>
+                            <version>${jetty.alpnAgent.version}</version>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/assembly/distribution-assembly.xml
+++ b/src/assembly/distribution-assembly.xml
@@ -19,6 +19,13 @@
     </dependencySets>
     <fileSets>
         <fileSet>
+            <directory>${jetty.alpnAgent.directory}</directory>
+            <includes>
+                <include>${jetty.alpnAgent.name}</include>
+            </includes>
+            <outputDirectory>/lib</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>${basedir}/webroot</directory>
             <filtered>false</filtered>
             <outputDirectory>/webroot</outputDirectory>

--- a/src/main/java/org/kairosdb/core/CoreModule.java
+++ b/src/main/java/org/kairosdb/core/CoreModule.java
@@ -31,6 +31,7 @@ import org.kairosdb.core.groupby.*;
 import org.kairosdb.core.http.rest.json.QueryParser;
 import org.kairosdb.core.jobs.CacheFileCleaner;
 import org.kairosdb.core.scheduler.KairosDBScheduler;
+import org.kairosdb.tracing.LightstepConfiguration;
 import org.kairosdb.util.MemoryMonitor;
 import org.kairosdb.util.Util;
 
@@ -139,5 +140,7 @@ public class CoreModule extends AbstractModule
 
 		String hostIp = m_props.getProperty("kairosdb.host_ip");
 		bindConstant().annotatedWith(Names.named("HOST_IP")).to(hostIp != null ? hostIp: InetAddresses.toAddrString(Util.findPublicIp()));
+
+		bind(LightstepConfiguration.class).in(Singleton.class);
 	}
 }

--- a/src/main/java/org/kairosdb/core/Main.java
+++ b/src/main/java/org/kairosdb/core/Main.java
@@ -39,7 +39,7 @@ import org.kairosdb.core.exception.DatastoreException;
 import org.kairosdb.core.exception.KairosDBException;
 import org.kairosdb.core.http.rest.json.DataPointsParser;
 import org.kairosdb.core.http.rest.json.ValidationErrors;
-import org.kairosdb.tracing.LightstepConfiguration;
+import org.kairosdb.tracing.TracingConfiguration;
 import org.kairosdb.util.PluginClassLoader;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -326,34 +326,6 @@ public class Main
 						}
 					}
 				}));
-
-
-				// OPENTRACING
-				LightstepConfiguration lightstepConfiguration = main.getInjector()
-						.getInstance(LightstepConfiguration.class);
-
-				if (!isNullOrEmpty(lightstepConfiguration.getAccessToken())
-						&& !isNullOrEmpty(lightstepConfiguration.getCollectorHost()))
-				{
-
-					Options opts = new com.lightstep.tracer.shared.Options.OptionsBuilder()
-							.withAccessToken(lightstepConfiguration.getAccessToken())
-							.withCollectorHost(lightstepConfiguration.getCollectorHost())
-							.withCollectorPort(lightstepConfiguration.getCollectorPort())
-							.withCollectorProtocol(lightstepConfiguration.getCollectorProtocol())
-							.withComponentName("zmon-kairosdb")
-							.build();
-
-					Tracer tracer = new com.lightstep.tracer.jre.JRETracer(opts);
-
-					GlobalTracer.register(tracer);
-
-					logger.info("OpenTracing support enabled.");
-				}
-				else
-				{
-					logger.info("OpenTracing support disabled.");
-				}
 
 				main.startServices();
 

--- a/src/main/java/org/kairosdb/tracing/LightstepConfiguration.java
+++ b/src/main/java/org/kairosdb/tracing/LightstepConfiguration.java
@@ -1,0 +1,63 @@
+package org.kairosdb.tracing;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+/**
+ * Created by abeverage on 12/4/17.
+ */
+public class LightstepConfiguration {
+
+	private static final String ACCESS_TOKEN = "tracing.lightstep.access_token";
+	private static final String COLLECTOR_HOST = "tracing.lightstep.collector_host";
+	private static final String COLLECTOR_PORT = "tracing.lightstep.collector_port";
+	private static final String COLLECTOR_PROTOCOL = "tracing.lightstep.collector_protocol";
+
+	@Inject
+	@Named(ACCESS_TOKEN)
+	private String accessToken;
+
+	@Inject
+	@Named(COLLECTOR_HOST)
+	private String collectorHost;
+
+	@Inject(optional = true)
+	@Named(COLLECTOR_PORT)
+	private int collectorPort;
+
+	@Inject(optional = true)
+	@Named(COLLECTOR_PROTOCOL)
+	private String collectorProtocol;
+
+	public String getAccessToken() {
+		return accessToken;
+	}
+
+	public void setAccessToken(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public String getCollectorHost() {
+		return collectorHost;
+	}
+
+	public void setCollectorHost(String collectorHost) {
+		this.collectorHost = collectorHost;
+	}
+
+	public int getCollectorPort() {
+		return collectorPort;
+	}
+
+	public void setCollectorPort(int collectorPort) {
+		this.collectorPort = collectorPort;
+	}
+
+	public String getCollectorProtocol() {
+		return collectorProtocol;
+	}
+
+	public void setCollectorProtocol(String collectorProtocol) {
+		this.collectorProtocol = collectorProtocol;
+	}
+}

--- a/src/main/java/org/kairosdb/tracing/TracingConfiguration.java
+++ b/src/main/java/org/kairosdb/tracing/TracingConfiguration.java
@@ -6,7 +6,7 @@ import com.google.inject.name.Named;
 /**
  * Created by abeverage on 12/4/17.
  */
-public class LightstepConfiguration {
+public class TracingConfiguration {
 
 	private static final String ACCESS_TOKEN = "tracing.lightstep.access_token";
 	private static final String COLLECTOR_HOST = "tracing.lightstep.collector_host";

--- a/src/scripts/kairosdb.sh
+++ b/src/scripts/kairosdb.sh
@@ -7,6 +7,9 @@ cd "$KAIROSDB_BIN_DIR/.."
 KAIROSDB_LIB_DIR="lib"
 KAIROSDB_LOG_DIR="log"
 
+# Must match version in pom:
+JETTY_ALPN_AGENT_VERSION=2.0.0
+
 if [ -f "$KAIROSDB_BIN_DIR/kairosdb-env.sh" ]; then
 	. "$KAIROSDB_BIN_DIR/kairosdb-env.sh"
 fi
@@ -41,7 +44,7 @@ done
 
 if [ "$1" = "run" ] ; then
 	shift
-	exec "$JAVA" $JAVA_OPTS -cp $CLASSPATH org.kairosdb.core.Main -c run -p conf/kairosdb.properties
+	exec "$JAVA" -javaagent:./lib/jetty-alpn-agent-$JETTY_ALPN_AGENT_VERSION.jar $JAVA_OPTS -cp $CLASSPATH org.kairosdb.core.Main -c run -p conf/kairosdb.properties
 elif [ "$1" = "start" ] ; then
 	shift
 	exec "$JAVA" $JAVA_OPTS -cp $CLASSPATH org.kairosdb.core.Main \


### PR DESCRIPTION
For our December POC.

Lightstep uses gRPC behind the scenes, which in its out-of-the-box form requires ALPN support.  KairosDB itself uses Jetty and requires the jetty-alpn extension to be on the boot classpath.  To get the right version we can use the jetty-alpn-agent.  The pom was updated to ensure its presence, and the KairosDB startup script updated to use it.  This will require us to maintain ALPN versioning infomation in two locations, pom.xml, and src/scripts/kairosdb.sh.

See:
- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#tls-with-jdk-jetty-alpnnpn
- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty

The rest of the changes are straightforward.  A configuration class for essential Lightstep values was added, and the default properties updated with empty values.  This is required or Guice will not attempt to populate the configuration class with provided environment variables.  These values include the Lightstep API key so should not ever be provided in the properties file itself.

Finally, the Main class was updated to register a global tracer if both an API key and a collector host were provided in the environment.  Port and protocol have defaults of https and 443, but can be overriden.  A tracer will not be registered if either the API key or collector host is not present.

Tested against a local dockerized Cassandra.