### PR TITLE
Remove datastore healthcheck

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -29,7 +29,7 @@ kairosdb.jetty.static_web_root=webroot
 
 #===============================================================================
 
-kairosdb.datastore.concurrentQueryThreads=25
+kairosdb.datastore.concurrentQueryThreads=35
 kairosdb.service.datastore=org.kairosdb.datastore.cassandra.CassandraModule
 
 #===============================================================================

--- a/src/main/java/org/kairosdb/core/health/HealthCheckModule.java
+++ b/src/main/java/org/kairosdb/core/health/HealthCheckModule.java
@@ -11,9 +11,6 @@ public class HealthCheckModule extends AbstractModule
 	protected void configure()
 	{
 		bind(HealthCheckService.class).to(HealthCheckServiceImpl.class).in(Singleton.class);
-		bind(ThreadDeadlockHealthStatus.class).in(Singleton.class);
-		bind(DatastoreQueryHealthCheck.class).in(Singleton.class);
-
 		// Bind REST resource
 		bind(HealthCheckResource.class).in(Scopes.SINGLETON);
 	}

--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/TagValueCacheConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/TagValueCacheConfiguration.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
 public class TagValueCacheConfiguration implements CacheConfiguration {
-    private static final String PREFIX = "kairosdb.datastore.cassandra.cache.tag_name.";
+    private static final String PREFIX = "kairosdb.datastore.cassandra.cache.tag_value.";
     private static final String TTL_IN_SECONDS = PREFIX + "ttl_in_seconds";
     private static final String SIZE = PREFIX + "size";
 


### PR DESCRIPTION
The main change is the removal of the health checks, namely the one that was querying the metric names constantly
Also fixed the metric key name for the tag values cache
Bumped the number of concurrent query runner threads from 25 to 35