### PR TITLE
added measurements for query span and distance

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -29,7 +29,7 @@ kairosdb.jetty.static_web_root=webroot
 
 #===============================================================================
 
-kairosdb.datastore.concurrentQueryThreads=35
+kairosdb.datastore.concurrentQueryThreads=25
 kairosdb.service.datastore=org.kairosdb.datastore.cassandra.CassandraModule
 
 #===============================================================================

--- a/src/main/java/org/kairosdb/core/CoreModule.java
+++ b/src/main/java/org/kairosdb/core/CoreModule.java
@@ -16,6 +16,7 @@
 
 package org.kairosdb.core;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.net.InetAddresses;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
@@ -70,6 +71,7 @@ public class CoreModule extends AbstractModule
 	@Override
 	protected void configure()
 	{
+		bind(MetricRegistry.class).in(Singleton.class);
 		bind(QueryQueuingManager.class).in(Singleton.class);
 		bind(KairosDatastore.class).in(Singleton.class);
 		bind(AggregatorFactory.class).to(GuiceAggregatorFactory.class).in(Singleton.class);

--- a/src/main/java/org/kairosdb/core/admin/CacheMetricsModule.java
+++ b/src/main/java/org/kairosdb/core/admin/CacheMetricsModule.java
@@ -1,14 +1,11 @@
 package org.kairosdb.core.admin;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
-
-import javax.inject.Singleton;
+import com.google.inject.Singleton;
 
 public class CacheMetricsModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(MetricRegistry.class).in(Singleton.class);
         bind(CacheMetricsProvider.class).to(DefaultCacheMetricsProvider.class).in(Singleton.class);
     }
 }

--- a/src/main/java/org/kairosdb/core/admin/CacheMetricsProvider.java
+++ b/src/main/java/org/kairosdb/core/admin/CacheMetricsProvider.java
@@ -1,23 +1,10 @@
 package org.kairosdb.core.admin;
 
-import com.codahale.metrics.Metric;
 import com.github.benmanes.caffeine.cache.Cache;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Map;
 
-public interface CacheMetricsProvider {
-    /**
-     * Returns the entire Map of Metrics.
-     */
-    Map<String, Metric> getAll();
-
-    /**
-     * Returns a Map of Metrics where the keys start with the given prefix.
-     */
-    Map<String, Metric> getForPrefix(@Nullable final String prefix);
-
+public interface CacheMetricsProvider extends InternalMetricsProvider {
     /**
      * Registers a a new cache in the metrics registry.
      *

--- a/src/main/java/org/kairosdb/core/admin/InternalMetricsProvider.java
+++ b/src/main/java/org/kairosdb/core/admin/InternalMetricsProvider.java
@@ -1,0 +1,22 @@
+package org.kairosdb.core.admin;
+
+import com.codahale.metrics.Metric;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public interface InternalMetricsProvider {
+    /**
+     * Returns the entire Map of Metrics.
+     */
+    Map<String, Metric> getAll();
+
+    /**
+     * Filters the metrics from the metrics registry using the provided prefix. When the prefix is null, or empty,
+     * an immediate copy of the metrics registry is returned.
+     *
+     * @param prefix a string that should match, case sensitive, with the keys from the metrics registry
+     * @return An immutable copy of the metrics that start with the given prefix
+     */
+    Map<String, Metric> getForPrefix(@Nullable final String prefix);
+}

--- a/src/main/java/org/kairosdb/core/http/WebServletModule.java
+++ b/src/main/java/org/kairosdb/core/http/WebServletModule.java
@@ -17,18 +17,15 @@ package org.kairosdb.core.http;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import com.google.inject.servlet.GuiceFilter;
-import com.google.inject.servlet.ServletModule;
-import com.google.inject.multibindings.Multibinder;
-import com.sun.jersey.api.container.filter.GZIPContentEncodingFilter;
 import com.sun.jersey.guice.JerseyServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
-import com.sun.jersey.spi.container.ContainerRequestFilter;
-import com.sun.jersey.spi.container.ContainerResponseFilter;
 import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
-import org.eclipse.jetty.server.handler.GzipHandler;
 import org.eclipse.jetty.servlets.GzipFilter;
 import org.kairosdb.core.http.rest.MetricsResource;
+import org.kairosdb.core.http.rest.metrics.DefaultQueryMeasurementProvider;
+import org.kairosdb.core.http.rest.metrics.QueryMeasurementProvider;
 
 import javax.ws.rs.core.MediaType;
 import java.util.Properties;
@@ -47,6 +44,8 @@ public class WebServletModule extends JerseyServletModule
 
 		//Bind web server
 		bind(WebServer.class);
+
+		bind(QueryMeasurementProvider.class).to(DefaultQueryMeasurementProvider.class).in(Singleton.class);
 
 		//Bind resource classes here
 		bind(MetricsResource.class).in(Scopes.SINGLETON);

--- a/src/main/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProvider.java
+++ b/src/main/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProvider.java
@@ -1,0 +1,80 @@
+package org.kairosdb.core.http.rest.metrics;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.kairosdb.core.admin.InternalMetricsProvider;
+import org.kairosdb.core.datastore.QueryMetric;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DefaultQueryMeasurementProvider implements QueryMeasurementProvider, InternalMetricsProvider {
+    private static final String MEASURES_PREFIX = "kairosdb.queries";
+
+    private final MetricRegistry metricRegistry;
+    private final Histogram spanHistogram;
+    private final Histogram distanceHistogram;
+
+    @Inject
+    public DefaultQueryMeasurementProvider(@Nonnull final MetricRegistry metricRegistry) {
+        checkNotNull(metricRegistry, "metricRegistry can't be null");
+        this.metricRegistry = metricRegistry;
+
+
+        spanHistogram = metricRegistry.histogram(MEASURES_PREFIX + ".span");
+        distanceHistogram = metricRegistry.histogram(MEASURES_PREFIX + ".distance");
+    }
+
+
+    @Override
+    public void measureSpan(final QueryMetric query) {
+        long endTime = query.getEndTime();
+        if(endTime == Long.MAX_VALUE) {
+            final DateTime nowUTC = new DateTime(DateTimeZone.UTC);
+            endTime = nowUTC.getMillis();
+        }
+        final long spanInMillis = endTime - query.getStartTime();
+        final long spanInMinutes = spanInMillis / 1000 / 60;
+        spanHistogram.update(spanInMinutes);
+    }
+
+    @Override
+    public void measureDistance(final QueryMetric query) {
+        final DateTime nowUTC = new DateTime(DateTimeZone.UTC);
+        final long distanceInMillis = nowUTC.getMillis() - query.getStartTime();
+        final long distanceInMinutes = distanceInMillis / 1000 / 60;
+        distanceHistogram.update(distanceInMinutes);
+    }
+
+    @Override
+    public Map<String, Metric> getAll() {
+        final Map<String, Metric> cacheMetrics = metricRegistry.getMetrics().entrySet().stream()
+                .filter(e -> e.getKey() != null && e.getKey().startsWith(MEASURES_PREFIX))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return ImmutableMap.copyOf(cacheMetrics);
+    }
+
+    @Override
+    public Map<String, Metric> getForPrefix(@Nullable final String prefix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return getAll();
+        }
+
+        final Map<String, Metric> filteredMetrics = getAll().entrySet().stream()
+                .filter(e -> e.getKey() != null && e.getKey().startsWith(MEASURES_PREFIX + "." + prefix))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return ImmutableMap.copyOf(filteredMetrics);
+    }
+}

--- a/src/main/java/org/kairosdb/core/http/rest/metrics/QueryMeasurementProvider.java
+++ b/src/main/java/org/kairosdb/core/http/rest/metrics/QueryMeasurementProvider.java
@@ -1,0 +1,9 @@
+package org.kairosdb.core.http.rest.metrics;
+
+import org.kairosdb.core.admin.InternalMetricsProvider;
+import org.kairosdb.core.datastore.QueryMetric;
+
+public interface QueryMeasurementProvider extends InternalMetricsProvider {
+    void measureSpan(QueryMetric query);
+    void measureDistance(QueryMetric query);
+}

--- a/src/main/java/org/kairosdb/core/reporting/CacheMetricsReporter.java
+++ b/src/main/java/org/kairosdb/core/reporting/CacheMetricsReporter.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.kairosdb.core.reporting.MetricReporterService.HOSTNAME;
 
 public class CacheMetricsReporter implements KairosMetricReporter {
-    private final CacheMetricsProvider cacheMetricsProvider;
+    private final CacheMetricsProvider metricsProvider;
 
     @Inject
     private LongDataPointFactory longDataPointFactory = new LongDataPointFactoryImpl();
@@ -30,17 +30,17 @@ public class CacheMetricsReporter implements KairosMetricReporter {
     private String hostname;
 
     @Inject
-    public CacheMetricsReporter(final CacheMetricsProvider cacheMetricsProvider, @Named(HOSTNAME) final String hostname) {
-        checkNotNull(cacheMetricsProvider, "cacheMetricsProvider can't be null");
+    public CacheMetricsReporter(final CacheMetricsProvider metricsProvider, @Named(HOSTNAME) final String hostname) {
+        checkNotNull(metricsProvider, "metricsProvider can't be null");
         checkNotNull(hostname, "hostname can't be null");
-        this.cacheMetricsProvider = cacheMetricsProvider;
+        this.metricsProvider = metricsProvider;
         this.hostname = hostname;
     }
 
     @Override
     public List<DataPointSet> getMetrics(final long now) {
         final ImmutableList.Builder<DataPointSet> builder = ImmutableList.builder();
-        final Map<String, Metric> metrics = cacheMetricsProvider.getAll();
+        final Map<String, Metric> metrics = metricsProvider.getAll();
         for (final Map.Entry<String, Metric> metric: metrics.entrySet()) {
             if(metric.getValue() instanceof Gauge) {
                 final Gauge gauge = (Gauge)metric.getValue();

--- a/src/main/java/org/kairosdb/core/reporting/MetricReporterService.java
+++ b/src/main/java/org/kairosdb/core/reporting/MetricReporterService.java
@@ -70,7 +70,7 @@ public class MetricReporterService implements KairosDBJob {
 
     @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
-        if(config.isEnabled()) {
+        if (config.isEnabled()) {
             logger.debug("Reporting metrics");
             long timestamp = System.currentTimeMillis();
             try {
@@ -78,7 +78,8 @@ public class MetricReporterService implements KairosDBJob {
                     List<DataPointSet> dpList = reporter.getMetrics(timestamp);
                     for (DataPointSet dataPointSet : dpList) {
                         for (DataPoint dataPoint : dataPointSet.getDataPoints()) {
-                            logger.debug("Storing internal metric {} = {}", dataPointSet.getName(), dataPoint);
+                            logger.debug("Storing internal metric {} {} = {}", dataPointSet.getName(),
+                                    dataPointSet.getTags(), dataPoint);
                             m_datastore.putDataPoint(dataPointSet.getName(), dataPointSet.getTags(), dataPoint);
                         }
                     }

--- a/src/main/java/org/kairosdb/core/reporting/MetricReportingModule.java
+++ b/src/main/java/org/kairosdb/core/reporting/MetricReportingModule.java
@@ -30,6 +30,7 @@ public class MetricReportingModule extends ServletModule {
 
         bind(RuntimeReporter.class).in(Scopes.SINGLETON);
         bind(CacheMetricsReporter.class).in(Scopes.SINGLETON);
+        bind(QueryMeasurementsReporter.class).in(Scopes.SINGLETON);
 
         bind(new TypeLiteral<List<KairosMetricReporter>>() {
         }).toProvider(KairosMetricReporterListProvider.class);

--- a/src/main/java/org/kairosdb/core/reporting/QueryMeasurementsReporter.java
+++ b/src/main/java/org/kairosdb/core/reporting/QueryMeasurementsReporter.java
@@ -1,0 +1,82 @@
+package org.kairosdb.core.reporting;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.Snapshot;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.DataPointSet;
+import org.kairosdb.core.datapoints.DoubleDataPointFactory;
+import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
+import org.kairosdb.core.datapoints.LongDataPointFactory;
+import org.kairosdb.core.datapoints.LongDataPointFactoryImpl;
+import org.kairosdb.core.http.rest.metrics.QueryMeasurementProvider;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.kairosdb.core.reporting.MetricReporterService.HOSTNAME;
+
+public class QueryMeasurementsReporter implements KairosMetricReporter {
+    @Inject
+    private LongDataPointFactory longDataPointFactory = new LongDataPointFactoryImpl();
+    @Inject
+    private DoubleDataPointFactory doubleDataPointFactory = new DoubleDataPointFactoryImpl();
+
+    private final QueryMeasurementProvider queryMeasurementProvider;
+
+    private String hostname;
+
+    @Inject
+    public QueryMeasurementsReporter(final QueryMeasurementProvider queryMeasurementProvider, @Named(HOSTNAME) final String hostname) {
+        checkNotNull(queryMeasurementProvider, "queryMeasurementProvider can't be null");
+        checkNotNull(hostname, "hostname can't be null");
+        this.queryMeasurementProvider = queryMeasurementProvider;
+        this.hostname = hostname;
+    }
+
+    @Override
+    public List<DataPointSet> getMetrics(final long now) {
+        final ImmutableList.Builder<DataPointSet> builder = ImmutableList.builder();
+        final Map<String, Metric> metrics = queryMeasurementProvider.getAll();
+        for (final Map.Entry<String, Metric> metric: metrics.entrySet()) {
+            if(metric.getValue() instanceof Histogram) {
+                final Histogram histogram = (Histogram) metric.getValue();
+                final Snapshot snapshot = histogram.getSnapshot();
+                final String metricName = metric.getKey();
+                builder.add(createDataPointSet(metricName, "max", now, snapshot.getMax()));
+                builder.add(createDataPointSet(metricName, "min", now, snapshot.getMin()));
+                builder.add(createDataPointSet(metricName, "mean", now, snapshot.getMean()));
+                builder.add(createDataPointSet(metricName, "median", now, snapshot.getMedian()));
+                builder.add(createDataPointSet(metricName, "p75", now, snapshot.get75thPercentile()));
+                builder.add(createDataPointSet(metricName, "p98", now, snapshot.get98thPercentile()));
+                builder.add(createDataPointSet(metricName, "p99", now, snapshot.get99thPercentile()));
+            }
+        }
+        return builder.build();
+    }
+
+    private DataPointSet createDataPointSet(final String metricName, final String key, final long timestamp,
+                                            final Number value) {
+        final DataPointSet dataPointSet = new DataPointSet(metricName);
+        final DataPoint dataPoint = createDataPoint(timestamp, value);
+        dataPointSet.addDataPoint(dataPoint);
+        dataPointSet.addTag("key", key);
+        dataPointSet.addTag("entity", hostname);
+        return dataPointSet;
+    }
+
+    private DataPoint createDataPoint(final long timestamp, final Number value) {
+        if(value instanceof Double || value instanceof Float) {
+            return doubleDataPointFactory.createDataPoint(timestamp, value.doubleValue());
+        } else {
+            return longDataPointFactory.createDataPoint(timestamp, value.longValue());
+        }
+
+    }
+
+}

--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/RowKeyCacheConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/RowKeyCacheConfiguration.java
@@ -10,7 +10,7 @@ public class RowKeyCacheConfiguration implements CacheConfiguration {
 
     @Inject(optional = true)
     @Named(TTL_IN_SECONDS)
-    private int ttlInSeconds = 259_200; // defaults to 1 day
+    private int ttlInSeconds = 259_200; // defaults to 3 days
 
     @Inject(optional = true)
     @Named(SIZE)


### PR DESCRIPTION
This is going to report regularly, from each node, two histograms:
- `kairosdb.queries.span`: the time between query start time and end time
- `kairosdb.queries.distance`: the time between query start time and the current date
Both measured in minutes.

Each metric contains the following tags (from the histogram), which are self explanatory:
* `max`
* `min`
* `mean`
* `mean`
* `median`
* `p75`
* `p98`
* `p99`