### PR TITLE
Separate configuration for new split index

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -90,5 +90,6 @@ kairosdb.datastore.cassandra.cache.tag_value.size=1024
 
 # New split index flags.  These can be removed after new row_key_split_index table
 # has filled over a 90-day window:
-kairosdb.datastore.cassandra.use-new-split-index=true
+kairosdb.datastore.cassandra.use-new-split-index-read=true
+kairosdb.datastore.cassandra.use-new-split-index-write=true
 kairosdb.datastore.cassandra.new-split-index-start-time-ms=9223372036854775807

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
@@ -49,18 +49,27 @@ public class CassandraConfiguration
 	public static final String CASSANDRA_INDEX_TAG_LIST = "kairosdb.datastore.cassandra.index_tag_list";
 
 	public static final String NEW_SPLIT_INDEX_START_TIME_MS = "kairosdb.datastore.cassandra.new-split-index-start-time-ms";
-	public static final String USE_NEW_SPLIT_INDEX = "kairosdb.datastore.cassandra.use-new-split-index";
+	public static final String USE_NEW_SPLIT_INDEX_READ = "kairosdb.datastore.cassandra.use-new-split-index-read";
+	public static final String USE_NEW_SPLIT_INDEX_WRITE = "kairosdb.datastore.cassandra.use-new-split-index-write";
 
 	@Inject(optional = true)
-	@Named(USE_NEW_SPLIT_INDEX)
-	private boolean m_useNewSplitIndex = false;
+	@Named(USE_NEW_SPLIT_INDEX_READ)
+	private boolean m_useNewSplitIndexRead = false;
+
+	@Inject(optional = true)
+	@Named(USE_NEW_SPLIT_INDEX_WRITE)
+	private boolean m_useNewSplitIndexWrite = false;
 
 	@Inject(optional = true)
 	@Named(NEW_SPLIT_INDEX_START_TIME_MS)
 	private long m_newSplitIndexStartTimeMs = 0l;
 
-	public boolean isUseNewSplitIndex() {
-		return m_useNewSplitIndex;
+	public boolean isUseNewSplitIndexRead() {
+		return m_useNewSplitIndexRead;
+	}
+
+	public boolean isUseNewSplitIndexWrite() {
+		return m_useNewSplitIndexWrite;
 	}
 
 	public long getNewSplitIndexStartTimeMs() {

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -298,7 +298,7 @@ public class CassandraDatastore implements Datastore {
             }
 
             storeRowKeySplit(m_psInsertRowKeySplit, metricName, serializedKey, rowKeyTtl, split, v);
-            if (m_cassandraConfiguration.isUseNewSplitIndex()) {
+            if (m_cassandraConfiguration.isUseNewSplitIndexWrite()) {
                 storeRowKeySplit(m_psInsertRowKeySplit2, metricName, serializedKey, rowKeyTtl, split, v);
             }
         }
@@ -683,7 +683,7 @@ public class CassandraDatastore implements Datastore {
 
             //  If any part of the query window falls before the new split index
             //  start time, use the old split index:
-            if (m_cassandraConfiguration.isUseNewSplitIndex() && startTime > m_cassandraConfiguration.getNewSplitIndexStartTimeMs()) {
+            if (m_cassandraConfiguration.isUseNewSplitIndexRead() && startTime > m_cassandraConfiguration.getNewSplitIndexStartTimeMs()) {
                 logger.info("Using new split index for query starting at {}.", startTime);
                 bs = m_psQueryRowKeySplitIndex2.bind();
             } else {


### PR DESCRIPTION
Now we can enable/disable read and write operations over new split index separately.