### PR TITLE
Implement a smart read

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -90,6 +90,6 @@ kairosdb.datastore.cassandra.cache.tag_value.size=1024
 
 # New split index flags.  These can be removed after new row_key_split_index table
 # has filled over a 90-day window:
-kairosdb.datastore.cassandra.use-new-split-index-read=true
-kairosdb.datastore.cassandra.use-new-split-index-write=true
-kairosdb.datastore.cassandra.new-split-index-start-time-ms=9223372036854775807
+kairosdb.datastore.cassandra.use_new_split_index_read=true
+kairosdb.datastore.cassandra.use_new_split_index_write=true
+kairosdb.datastore.cassandra.new_split_index_start_time_ms=9223372036854775807

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
@@ -48,9 +48,9 @@ public class CassandraConfiguration
 
 	public static final String CASSANDRA_INDEX_TAG_LIST = "kairosdb.datastore.cassandra.index_tag_list";
 
-	public static final String NEW_SPLIT_INDEX_START_TIME_MS = "kairosdb.datastore.cassandra.new-split-index-start-time-ms";
-	public static final String USE_NEW_SPLIT_INDEX_READ = "kairosdb.datastore.cassandra.use-new-split-index-read";
-	public static final String USE_NEW_SPLIT_INDEX_WRITE = "kairosdb.datastore.cassandra.use-new-split-index-write";
+	public static final String NEW_SPLIT_INDEX_START_TIME_MS = "kairosdb.datastore.cassandra.new_split_index_start_time_ms";
+	public static final String USE_NEW_SPLIT_INDEX_READ = "kairosdb.datastore.cassandra.use_new_split_index_read";
+	public static final String USE_NEW_SPLIT_INDEX_WRITE = "kairosdb.datastore.cassandra.use_new_split_index_write";
 
 	@Inject(optional = true)
 	@Named(USE_NEW_SPLIT_INDEX_READ)

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -860,7 +860,14 @@ public class CassandraDatastore implements Datastore {
         final DataPointsRowKeySerializer keySerializer = new DataPointsRowKeySerializer();
 
         final BoundStatement bs = statement.bind();
-        bs.setString(0, metricName);
+        ByteBuffer bMetricName;
+        try {
+            bMetricName = ByteBuffer.wrap(metricName.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        bs.setBytes(0, bMetricName);
         bs.setInt(3, limit);
 
 


### PR DESCRIPTION
This commit introduces a "smart read" approach for getting data
from row_key_split_index table.
Basically, it tries to read the data from new row_key_split_index_2
table first (time interval is inclusive for both boundaries). Then
it tries to fetch the rest of the data from old row_key_split_index
table. In latter case time interval EXCLUDES the upper boundary, so for
fetching data from timestamp 12345 to timestamp 23456, all records
for 23456 won't be fetched from the old table. They are expected to come
from new table.