### PR TITLE
Fixes bug of no reporting span and distance metrics

### DIFF
--- a/src/main/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProvider.java
+++ b/src/main/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProvider.java
@@ -33,11 +33,11 @@ public class DefaultQueryMeasurementProvider implements QueryMeasurementProvider
         checkNotNull(metricRegistry, "metricRegistry can't be null");
         this.metricRegistry = metricRegistry;
 
-        spanHistogramSuccess = metricRegistry.histogram(MEASURES_PREFIX + ".span.success");
-        distanceHistogramSuccess = metricRegistry.histogram(MEASURES_PREFIX + ".distance.success");
+        spanHistogramSuccess = metricRegistry.histogram(MEASURES_PREFIX + "span.success");
+        distanceHistogramSuccess = metricRegistry.histogram(MEASURES_PREFIX + "distance.success");
 
-        spanHistogramError = metricRegistry.histogram(MEASURES_PREFIX + ".span.error");
-        distanceHistogramError = metricRegistry.histogram(MEASURES_PREFIX + ".distance.error");
+        spanHistogramError = metricRegistry.histogram(MEASURES_PREFIX + "span.error");
+        distanceHistogramError = metricRegistry.histogram(MEASURES_PREFIX + "distance.error");
     }
 
 

--- a/src/test/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProviderTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProviderTest.java
@@ -1,0 +1,46 @@
+package org.kairosdb.core.http.rest.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.Test;
+import org.kairosdb.core.datastore.QueryMetric;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DefaultQueryMeasurementProviderTest {
+
+    @Test
+    public void testCreatesNecessaryHistograms() {
+        final MetricRegistry registry = new MetricRegistry();
+        final DefaultQueryMeasurementProvider provider = new DefaultQueryMeasurementProvider(registry);
+
+        Set<String> names = registry.getNames();
+
+        assertEquals(4, names.size());
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.span.success".equals(item)));
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.distance.success".equals(item)));
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.span.error".equals(item)));
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.distance.error".equals(item)));
+    }
+
+    @Test
+    public void testIgnoresMetricsStartingWithPrefix() {
+        final MetricRegistry registry = new MetricRegistry();
+        final DefaultQueryMeasurementProvider provider = new DefaultQueryMeasurementProvider(registry);
+        provider.measureSpanForMetric(new QueryMetric(0l, 0, "foo"));
+        provider.measureSpanForMetric(new QueryMetric(0l, 0, "foo"));
+        provider.measureSpanForMetric(new QueryMetric(0l, 0, "kairosdb.queries.foo"));
+
+        Set<String> names = registry.getNames();
+
+        assertEquals(5, names.size());
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.span.success".equals(item)));
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.distance.success".equals(item)));
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.span.error".equals(item)));
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.distance.error".equals(item)));
+        assertTrue(names.stream().anyMatch(item -> "kairosdb.queries.foo.span".equals(item)));
+    }
+
+}


### PR DESCRIPTION
Specifically `kairosdb.queries.*.span` and `kairosdb.queries.*.distance`