### PR TITLE
Reduce data retention in kairosDB

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -60,7 +60,7 @@ kairosdb.datastore.cassandra.read_row_width=1814400000
 kairosdb.datastore.cassandra.increase_buffer_size_schedule=0 */5 * * * ?
 
 #3 months in seconds
-kairosdb.datastore.cassandra.datapoint_ttl=8070400
+kairosdb.datastore.cassandra.datapoint_ttl=3024000
 
 #===============================================================================
 # Cache file cleaning schedule. Uses Quartz Cron syntax


### PR DESCRIPTION
Updated the TTL in kairosdb configuration and reduced it to 35 days or 3024000 seconds