### PR TITLE
span tags for read and write path endpoints

### DIFF
--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -93,5 +93,3 @@ kairosdb.datastore.cassandra.cache.tag_value.size=1024
 kairosdb.datastore.cassandra.use_new_split_index_read=true
 kairosdb.datastore.cassandra.use_new_split_index_write=true
 kairosdb.datastore.cassandra.new_split_index_start_time_ms=9223372036854775807
-
-kairosdb.datastore.cassandra.max_rows_for_key_query=5

--- a/conf/kairosdb.properties
+++ b/conf/kairosdb.properties
@@ -93,3 +93,5 @@ kairosdb.datastore.cassandra.cache.tag_value.size=1024
 kairosdb.datastore.cassandra.use_new_split_index_read=true
 kairosdb.datastore.cassandra.use_new_split_index_write=true
 kairosdb.datastore.cassandra.new_split_index_start_time_ms=9223372036854775807
+
+kairosdb.datastore.cassandra.max_rows_for_key_query=5

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -503,7 +503,6 @@ public class MetricsResource implements KairosMetricReporter
 		{
 			JsonResponseBuilder builder = new JsonResponseBuilder(Response.Status.BAD_REQUEST);
 			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log("JsonSyntaxException");
 			span.log(e.getMessage());
 			return builder.addError(e.getMessage()).build();
 		}
@@ -511,7 +510,6 @@ public class MetricsResource implements KairosMetricReporter
 		{
 			JsonResponseBuilder builder = new JsonResponseBuilder(Response.Status.BAD_REQUEST);
 			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log("QueryException");
 			span.log(e.getMessage());
 			return builder.addError(e.getMessage()).build();
 		}
@@ -519,23 +517,20 @@ public class MetricsResource implements KairosMetricReporter
 		{
 			JsonResponseBuilder builder = new JsonResponseBuilder(Response.Status.BAD_REQUEST);
 			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log("BeanValidationException");
 			span.log(e.getMessage());
 			return builder.addErrors(e.getErrorMessages()).build();
 		}
 		catch (MaxRowKeysForQueryExceededException e) {
 			logger.error("Query failed with too many rows", e);
 			JsonResponseBuilder builder = new JsonResponseBuilder(Response.Status.BAD_REQUEST);
-			//Tags.ERROR.set(span, Boolean.TRUE);
-			span.setTag("max_row_keys", Boolean.TRUE);
-			//span.log(e.getMessage());
+			Tags.ERROR.set(span, Boolean.TRUE);
+			span.log(e.getMessage());
 			return builder.addError(e.getMessage()).build();
 		}
 		catch (MemoryMonitorException e)
 		{
 			logger.error("Query failed.", e);
 			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log("MemoryMonitorException");
 			span.log(e.getMessage());
 			Thread.sleep(1000);
 			System.gc();
@@ -545,7 +540,6 @@ public class MetricsResource implements KairosMetricReporter
 		{
 			logger.error("Failed to open temp folder "+datastore.getCacheDir(), e);
 			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log("IOException");
 			span.log(e.getMessage());
 			return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
 		}
@@ -553,7 +547,6 @@ public class MetricsResource implements KairosMetricReporter
 		{
 			logger.error("Query failed.", e);
 			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log("Exception");
 			span.log(e.getMessage());
 			return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
 		}
@@ -561,7 +554,6 @@ public class MetricsResource implements KairosMetricReporter
 		{
 			logger.error("Out of memory error.", e);
 			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log("OutOfMemoryError");
 			span.log(e.getMessage());
 			return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
 		}

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -248,7 +248,7 @@ public class MetricsResource implements KairosMetricReporter
 					gson, m_kairosDataPointFactory);
 			ValidationErrors validationErrors = parser.parse();
 
-			span.setTag("datapoint_count", parser.getDataPointCount());
+			span.log("datapoint_count: " + parser.getDataPointCount());
 			m_ingestedDataPoints.addAndGet(parser.getDataPointCount());
 			m_ingestTime.addAndGet(parser.getIngestTime());
 

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -476,7 +476,12 @@ public class MetricsResource implements KairosMetricReporter
 				try {
 					List<DataPointGroup> results = dq.execute();
 					jsonResponse.formatQuery(results, query.isExcludeTags(), dq.getSampleSize());
-				} finally
+				} catch (Throwable e) {
+					queryMeasurementProvider.measureSpanError(query);
+					queryMeasurementProvider.measureDistanceError(query);
+					throw e;
+				}
+				finally
 				{
 					queryMeasurementProvider.measureSpanSuccess(query);
 					queryMeasurementProvider.measureDistanceSuccess(query);

--- a/src/main/java/org/kairosdb/core/http/rest/json/DataPointsParser.java
+++ b/src/main/java/org/kairosdb/core/http/rest/json/DataPointsParser.java
@@ -23,8 +23,6 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
-import com.google.inject.Inject;
-import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 import org.kairosdb.core.KairosDataPointFactory;
 import org.kairosdb.core.datastore.KairosDatastore;
@@ -65,9 +63,6 @@ public class DataPointsParser
 
 	private int dataPointCount;
 	private int ingestTime;
-
-	@Inject
-	private Tracer tracer;
 
 	public DataPointsParser(KairosDatastore datastore, Reader stream, Gson gson,
 	                        KairosDataPointFactory dataPointFactory)

--- a/src/main/java/org/kairosdb/core/http/rest/json/DataPointsParser.java
+++ b/src/main/java/org/kairosdb/core/http/rest/json/DataPointsParser.java
@@ -25,6 +25,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.inject.Inject;
 import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 import org.kairosdb.core.KairosDataPointFactory;
 import org.kairosdb.core.datastore.KairosDatastore;
 import org.kairosdb.core.exception.DatastoreException;
@@ -97,6 +98,8 @@ public class DataPointsParser
 					while (reader.hasNext())
 					{
 						NewMetric metric = parseMetric(reader);
+						GlobalTracer.get().activeSpan().log("metric_name " + metric.name);  //Experimental, will be tweaked/removed after testing
+						GlobalTracer.get().activeSpan().log("tags: " + metric.tags.toString()); //Experimental, will be tweaked/removed after testing
 						validateAndAddDataPoints(metric, validationErrors, metricCount);
 						metricCount++;
 					}
@@ -111,8 +114,8 @@ public class DataPointsParser
 			else if (reader.peek().equals(JsonToken.BEGIN_OBJECT))
 			{
 				NewMetric metric = parseMetric(reader);
-				tracer.activeSpan().setTag("metric_name", metric.name);
-				tracer.activeSpan().log("tags: " + metric.tags.toString());
+				GlobalTracer.get().activeSpan().setTag("metric_name", metric.name);
+				GlobalTracer.get().activeSpan().log("tags: " + metric.tags.toString());
 				validateAndAddDataPoints(metric, validationErrors, 0);
 			}
 			else

--- a/src/main/java/org/kairosdb/core/http/rest/json/DataPointsParser.java
+++ b/src/main/java/org/kairosdb/core/http/rest/json/DataPointsParser.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
+import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 import org.kairosdb.core.KairosDataPointFactory;
 import org.kairosdb.core.datastore.KairosDatastore;
@@ -33,7 +34,9 @@ import org.kairosdb.util.Validator;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -82,6 +85,9 @@ public class DataPointsParser
 
 		try
 		{
+			Span span = GlobalTracer.get().activeSpan();
+			List<String> list = new ArrayList<String>();
+
 			int metricCount = 0;
 
 			if (reader.peek().equals(JsonToken.BEGIN_ARRAY))
@@ -93,10 +99,17 @@ public class DataPointsParser
 					while (reader.hasNext())
 					{
 						NewMetric metric = parseMetric(reader);
-						GlobalTracer.get().activeSpan().log("metric_name " + metric.name);  //Experimental, will be tweaked/removed after testing
-						GlobalTracer.get().activeSpan().log("tags: " + metric.tags.toString()); //Experimental, will be tweaked/removed after testing
+
+						if(!list.contains(metric.name)) {
+							list.add(metric.name);
+						}
+
 						validateAndAddDataPoints(metric, validationErrors, metricCount);
 						metricCount++;
+					}
+
+					if ( span!= null) {
+						span.log("metric_name: " + list.toString());
 					}
 				}
 				catch (EOFException e)
@@ -109,8 +122,9 @@ public class DataPointsParser
 			else if (reader.peek().equals(JsonToken.BEGIN_OBJECT))
 			{
 				NewMetric metric = parseMetric(reader);
-				GlobalTracer.get().activeSpan().setTag("metric_name", metric.name);
-				GlobalTracer.get().activeSpan().log("tags: " + metric.tags.toString());
+				if ( span!= null) {
+					span.log("metric_name" + metric.name);
+				}
 				validateAndAddDataPoints(metric, validationErrors, 0);
 			}
 			else

--- a/src/main/java/org/kairosdb/core/opentracing/HttpHeadersCarrier.java
+++ b/src/main/java/org/kairosdb/core/opentracing/HttpHeadersCarrier.java
@@ -31,5 +31,4 @@ public class HttpHeadersCarrier implements TextMap {
     public Iterator<Map.Entry<String, String>> iterator() {
         return new HttpServletRequestExtractAdapter.MultivaluedMapFlatIterator<>(httpHeaders.entrySet());
     }
-
 }

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -225,16 +225,16 @@ public class CassandraDatastore implements Datastore {
             final boolean rowKeyKnown = rowKeyCache.isKnown(serializedKey);
             if (!rowKeyKnown) {
                 storeRowKeyReverseLookups(metricName, serializedKey, rowKeyTtl, tags);
-                if ( span != null) {
-                    span.setTag("row_key_not_in_cache", Boolean.TRUE);
+                if (span != null) {
+                    span.setTag("cache_miss_row_key", Boolean.TRUE);
                 }
 
                 rowKeyCache.put(serializedKey);
 
                 //Write metric name if not in cache
                 if (!metricNameCache.isKnown(metricName)) {
-                    if ( span != null) {
-                        span.setTag("metric_name_not_in_cache", Boolean.TRUE);
+                    if (span != null) {
+                        span.setTag("cache_miss_metric_name", Boolean.TRUE);
                     }
                     if (metricName.length() == 0) {
                         logger.warn("Attempted to add empty metric name to string index. Row looks like: {}", dataPoint);
@@ -246,8 +246,8 @@ public class CassandraDatastore implements Datastore {
                 //Check tag names and values to write them out
                 for (final String tagName : tags.keySet()) {
                     if (!tagNameCache.isKnown(tagName)) {
-                        if ( span != null) {
-                            span.setTag("tag_name_not_in_cache", Boolean.TRUE);
+                        if (span != null) {
+                            span.setTag("cache_miss_tag_name", Boolean.TRUE);
                         }
                         if (tagName.length() == 0) {
                             logger.warn("Attempted to add empty tagName to string cache for metric: {}", metricName);
@@ -259,8 +259,8 @@ public class CassandraDatastore implements Datastore {
                     final String value = tags.get(tagName);
                     boolean isCachedValue = tagValueCache.isKnown(value);
                     if (m_cassandraConfiguration.getTagValueCacheSize() > 0 && !isCachedValue) {
-                        if ( span != null) {
-                            span.setTag("tag_value_not_in_cache", Boolean.TRUE);
+                        if (span != null) {
+                            span.setTag("cache_miss_tag_value", Boolean.TRUE);
                         }
                         if (value.length() == 0) {
                             logger.warn("Attempted to add empty tagValue (tag name {}) to string cache for metric: {}",
@@ -519,6 +519,7 @@ public class CassandraDatastore implements Datastore {
      * @return row keys for the query
      */
     public Collection<DataPointsRowKey> getKeysForQueryIterator(DatastoreMetricQuery query, int limit) {
+        Span span = GlobalTracer.get().activeSpan();
         Collection<DataPointsRowKey> ret = null;
 
         List<QueryPlugin> plugins = query.getPlugins();
@@ -538,8 +539,11 @@ public class CassandraDatastore implements Datastore {
         }
 
         if (ret.size() > m_cassandraConfiguration.getMaxRowKeysForQuery()) {
-            GlobalTracer.get().activeSpan().setTag("row_count", ret.size());
-            GlobalTracer.get().activeSpan().setTag("max_row_keys", Boolean.TRUE);
+            if(span != null) {
+                span.setTag("row_count", ret.size());
+                span.setTag("max_row_keys", Boolean.TRUE);
+            }
+
             throw new MaxRowKeysForQueryExceededException(String.format("Query for metric %s matches %d row keys, but only %d are allowed",
                     query.getName(), ret.size(), m_cassandraConfiguration.getMaxRowKeysForQuery()));
         }
@@ -639,6 +643,7 @@ public class CassandraDatastore implements Datastore {
     }
 
     private static void filterAndAddKeys(String metricName, SetMultimap<String, String> filterTags, ResultSet rs, List<DataPointsRowKey> targetList, int limit) {
+        Span span = GlobalTracer.get().activeSpan();
         long startTime = System.currentTimeMillis();
         final DataPointsRowKeySerializer keySerializer = new DataPointsRowKeySerializer();
         final SetMultimap<String, Pattern> tagPatterns = MultimapBuilder.hashKeys(filterTags.size()).hashSetValues().build();
@@ -650,8 +655,11 @@ public class CassandraDatastore implements Datastore {
             i++;
 
             if (i > limit) {
-                GlobalTracer.get().activeSpan().setTag("row_count", i);
-                GlobalTracer.get().activeSpan().setTag("max_row_keys", Boolean.TRUE);
+                if(span != null) {
+                    span.setTag("row_count", i);
+                    span.setTag("max_row_keys", Boolean.TRUE);
+                }
+
                 throw new MaxRowKeysForQueryExceededException(String.format("Too many rows too scan: metric=%s limit=%d", metricName, limit));
             }
 

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.*;
 import com.google.common.collect.*;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import io.opentracing.util.GlobalTracer;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.KairosDataPointFactory;
 import org.kairosdb.core.datapoints.LegacyDataPointFactory;
@@ -523,6 +524,8 @@ public class CassandraDatastore implements Datastore {
         }
 
         if (ret.size() > m_cassandraConfiguration.getMaxRowKeysForQuery()) {
+            GlobalTracer.get().activeSpan().setTag("row_count", ret.size());
+            GlobalTracer.get().activeSpan().setTag("max_row_keys", Boolean.TRUE);
             throw new MaxRowKeysForQueryExceededException(String.format("Query for metric %s matches %d row keys, but only %d are allowed",
                     query.getName(), ret.size(), m_cassandraConfiguration.getMaxRowKeysForQuery()));
         }
@@ -633,6 +636,8 @@ public class CassandraDatastore implements Datastore {
             i++;
 
             if (i > limit) {
+                GlobalTracer.get().activeSpan().setTag("row_count", i);
+                GlobalTracer.get().activeSpan().setTag("max_row_keys", Boolean.TRUE);
                 throw new MaxRowKeysForQueryExceededException(String.format("Too many rows too scan: metric=%s limit=%d", metricName, limit));
             }
 


### PR DESCRIPTION
Fixed max_row_key tag for read path.
Added span.logs for metric_name and tags while inserting datapoints. Based on observation may change it to tags, if required.