### PR TITLE
Added query waiting count span tag for datapoints query.

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -249,7 +249,7 @@ public class KairosDatastore
 
 		DatastoreQuery dq;
 
-		Span span = GlobalTracer.get().activeSpan();
+		Span span = tracer.activeSpan();
 
 		try
 		{

--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -25,6 +25,7 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.DataPointListener;
 import org.kairosdb.core.KairosDataPointFactory;
@@ -248,32 +249,24 @@ public class KairosDatastore
 
 		DatastoreQuery dq;
 
-		Span span = tracer.buildSpan("create_query").start();
+		Span span = GlobalTracer.get().activeSpan();
 
-		try(Scope scope = tracer.scopeManager().activate(span, false))
+		try
 		{
 			dq = new DatastoreQueryImpl(metric);
 			span.setTag("query_waiting_count", m_queuingManager.getQueryWaitingCount());
 		}
 		catch (UnsupportedEncodingException e)
 		{
-			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log(e.getMessage());
 			throw new DatastoreException(e);
 		}
 		catch (NoSuchAlgorithmException e)
 		{
-			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log(e.getMessage());
 			throw new DatastoreException(e);
 		}
 		catch (InterruptedException e)
 		{
-			Tags.ERROR.set(span, Boolean.TRUE);
-			span.log(e.getMessage());
 			throw new DatastoreException(e);
-		}finally {
-			span.finish();
 		}
 
 		return (dq);

--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -67,13 +67,12 @@ public class KairosDatastore
 	private String m_baseCacheDir;
 	private volatile String m_cacheDir;
 
-	@Inject
 	private Tracer tracer;
 
 	@SuppressWarnings("ResultOfMethodCallIgnored")
 	@Inject
 	public KairosDatastore(Datastore datastore, QueryQueuingManager queuingManager,
-	      List<DataPointListener> dataPointListeners, KairosDataPointFactory dataPointFactory)
+	      List<DataPointListener> dataPointListeners, KairosDataPointFactory dataPointFactory, Tracer tracer)
 			throws DatastoreException
 	{
 		m_datastore = checkNotNull(datastore);
@@ -84,6 +83,8 @@ public class KairosDatastore
 		m_baseCacheDir = System.getProperty("java.io.tmpdir") + "/kairos_cache/";
 
 		setupCacheDirectory();
+
+		this.tracer = tracer;
 	}
 
 	@SuppressWarnings("UnusedDeclaration")
@@ -254,7 +255,10 @@ public class KairosDatastore
 		try
 		{
 			dq = new DatastoreQueryImpl(metric);
-			span.setTag("query_waiting_count", m_queuingManager.getQueryWaitingCount());
+			if(span != null) {
+				span.setTag("query_waiting_count", m_queuingManager.getQueryWaitingCount());
+			}
+
 		}
 		catch (UnsupportedEncodingException e)
 		{

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -101,12 +101,11 @@ public class MetricsResource implements KairosMetricReporter
 
 	private QueryMeasurementProvider queryMeasurementProvider;
 
-	@Inject
 	private Tracer tracer;
 
 	@Inject
 	public MetricsResource(KairosDatastore datastore, QueryParser queryParser,
-			KairosDataPointFactory dataPointFactory, QueryMeasurementProvider queryMeasurementProvider)
+			KairosDataPointFactory dataPointFactory, QueryMeasurementProvider queryMeasurementProvider, Tracer tracer)
 	{
 		this.datastore = checkNotNull(datastore);
 		this.queryParser = checkNotNull(queryParser);
@@ -116,6 +115,8 @@ public class MetricsResource implements KairosMetricReporter
 
 		GsonBuilder builder = new GsonBuilder();
 		gson = builder.create();
+
+		this.tracer = tracer;
 	}
 
 	private ResponseBuilder setHeaders(ResponseBuilder responseBuilder)


### PR DESCRIPTION
This will help understand the queue up of queries on kairosdb when cassandra takes long to respond. Tested on local docker-compose build for zmon.