### PR TITLE
Added query waiting count span tag for datapoints query.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
 	<skipTests>true</skipTests>
         <argLine />
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -250,6 +249,12 @@
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-web-servlet-filter</artifactId>
             <version>0.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <version>0.31.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -101,12 +101,11 @@ public class MetricsResource implements KairosMetricReporter
 
 	private QueryMeasurementProvider queryMeasurementProvider;
 
-	@Inject
 	private Tracer tracer;
 
 	@Inject
 	public MetricsResource(KairosDatastore datastore, QueryParser queryParser,
-			KairosDataPointFactory dataPointFactory, QueryMeasurementProvider queryMeasurementProvider)
+			KairosDataPointFactory dataPointFactory, QueryMeasurementProvider queryMeasurementProvider, Tracer tracer)
 	{
 		this.datastore = checkNotNull(datastore);
 		this.queryParser = checkNotNull(queryParser);
@@ -116,6 +115,8 @@ public class MetricsResource implements KairosMetricReporter
 
 		GsonBuilder builder = new GsonBuilder();
 		gson = builder.create();
+
+		this.tracer = tracer;
 	}
 
 	private ResponseBuilder setHeaders(ResponseBuilder responseBuilder)

--- a/src/test/java/org/kairosdb/core/datastore/KairosDatastoreTest.java
+++ b/src/test/java/org/kairosdb/core/datastore/KairosDatastoreTest.java
@@ -16,6 +16,7 @@
 package org.kairosdb.core.datastore;
 
 import com.google.common.collect.ImmutableSortedMap;
+import io.opentracing.mock.MockTracer;
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.DataPointListener;
@@ -32,6 +33,7 @@ import org.kairosdb.core.formatter.FormatterException;
 import org.kairosdb.core.groupby.GroupByResult;
 import org.kairosdb.core.groupby.TagGroupBy;
 import org.kairosdb.core.groupby.TagGroupByResult;
+import org.mockito.Mock;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,6 +52,7 @@ import static org.junit.Assert.assertThat;
 public class KairosDatastoreTest
 {
 	private AggregatorFactory aggFactory;
+	private static MockTracer tracer = new MockTracer();
 
 	public KairosDatastoreTest() throws KairosDBException
 	{
@@ -61,7 +64,7 @@ public class KairosDatastoreTest
 	{
 		TestDatastore testds = new TestDatastore();
 		KairosDatastore datastore = new KairosDatastore(testds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), new TestDataPointFactory());
+				Collections.<DataPointListener>emptyList(), new TestDataPointFactory(), tracer);
 
 		datastore.createQuery(null);
 	}
@@ -71,7 +74,7 @@ public class KairosDatastoreTest
 	{
 		TestDatastore testds = new TestDatastore();
 		KairosDatastore datastore = new KairosDatastore(testds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), new TestDataPointFactory());
+				Collections.<DataPointListener>emptyList(), new TestDataPointFactory(), tracer);
 		QueryMetric metric = new QueryMetric(1L, 1, "metric1");
 		metric.addAggregator(aggFactory.createAggregator("sum"));
 
@@ -100,7 +103,7 @@ public class KairosDatastoreTest
 	{
 		TestDatastore testds = new TestDatastore();
 		KairosDatastore datastore = new KairosDatastore(testds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), new TestDataPointFactory());
+				Collections.<DataPointListener>emptyList(), new TestDataPointFactory(), tracer);
 		QueryMetric metric = new QueryMetric(1L, 1, "metric1");
 
 		DatastoreQuery dq = datastore.createQuery(metric);
@@ -174,7 +177,7 @@ public class KairosDatastoreTest
 	{
 		TestDatastore testds = new TestDatastore();
 		KairosDatastore datastore = new KairosDatastore(testds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), new TestDataPointFactory());
+				Collections.<DataPointListener>emptyList(), new TestDataPointFactory(), tracer);
 
 		// Create files in the cache directory
 		File cacheDir = new File(datastore.getCacheDir());
@@ -319,7 +322,7 @@ public class KairosDatastoreTest
 		                           List<DataPointListener> dataPointListeners,
 		                           KairosDataPointFactory dataPointFactory) throws DatastoreException
 		{
-			super(datastore, queuingManager, dataPointListeners, dataPointFactory);
+			super(datastore, queuingManager, dataPointListeners, dataPointFactory, tracer);
 		}
 	}
 

--- a/src/test/java/org/kairosdb/core/http/rest/json/DataPointsParserTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/json/DataPointsParserTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import io.opentracing.mock.MockTracer;
 import org.junit.Test;
 import org.kairosdb.core.*;
 import org.kairosdb.core.datapoints.StringDataPoint;
@@ -42,6 +43,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class DataPointsParserTest
 {
 	private static KairosDataPointFactory dataPointFactory = new TestDataPointFactory();
+	private static MockTracer tracer = new MockTracer();
+
 	@Test
 	public void test_emptyJson_Invalid() throws DatastoreException, IOException
 	{
@@ -49,7 +52,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), new TestDataPointFactory());
+				Collections.<DataPointListener>emptyList(), new TestDataPointFactory(), tracer);
 
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json), new Gson(),
 				dataPointFactory);
@@ -67,7 +70,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
@@ -85,7 +88,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -102,7 +105,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -119,7 +122,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -136,7 +139,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -153,7 +156,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -170,7 +173,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -187,7 +190,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -204,7 +207,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -221,7 +224,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -238,7 +241,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -255,7 +258,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -272,7 +275,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -289,7 +292,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -307,7 +310,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -325,7 +328,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -342,7 +345,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -360,7 +363,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -381,7 +384,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -397,7 +400,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -423,7 +426,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -448,7 +451,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -478,7 +481,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -518,7 +521,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -571,7 +574,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -597,7 +600,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -623,7 +626,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -649,7 +652,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -675,7 +678,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 		DataPointsParser parser = new DataPointsParser(datastore, new StringReader(json),
 				new Gson(), dataPointFactory);
 
@@ -707,7 +710,7 @@ public class DataPointsParserTest
 
 		FakeDataStore fakeds = new FakeDataStore();
 		KairosDatastore datastore = new KairosDatastore(fakeds, new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 
 		DataPointsParser parser = new DataPointsParser(datastore, skipReader,
 				new Gson(), dataPointFactory);

--- a/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
+++ b/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import java.net.SocketAddress;
 import java.util.Collections;
 
+import io.opentracing.mock.MockTracer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelConfig;
 import org.jboss.netty.channel.ChannelFactory;
@@ -50,13 +51,14 @@ public class PutCommandTest
 {
 	private PutCommand command;
 	private FakeDatastore datastore;
+	private static MockTracer tracer = new MockTracer();
 
 	@Before
 	public void setup() throws DatastoreException
 	{
 		datastore = new FakeDatastore();
 		KairosDatastore kairosDatastore = new KairosDatastore(datastore, new QueryQueuingManager(1, "test"),
-				Collections.<DataPointListener>emptyList(), new TestDataPointFactory());
+				Collections.<DataPointListener>emptyList(), new TestDataPointFactory(), tracer);
 		command = new PutCommand(kairosDatastore, "test", new LongDataPointFactoryImpl(),
 				new DoubleDataPointFactoryImpl());
 	}

--- a/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
@@ -17,6 +17,7 @@ package org.kairosdb.datastore.cassandra;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import io.opentracing.mock.MockTracer;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -56,6 +57,7 @@ public class CassandraDatastoreTest extends DatastoreTestHelper {
     private static CassandraDatastore s_datastore;
     private static long s_dataPointTime;
     public static final HashMultimap<String, String> EMPTY_MAP = HashMultimap.create();
+    private static MockTracer tracer = new MockTracer();
 
     private static void putDataPoints(DataPointSet dps) throws DatastoreException {
         for (DataPoint dataPoint : dps.getDataPoints()) {
@@ -188,7 +190,7 @@ public class CassandraDatastoreTest extends DatastoreTestHelper {
         System.out.println("Creating KairosDataStore");
         DatastoreTestHelper.s_datastore = new KairosDatastore(s_datastore,
                 new QueryQueuingManager(1, "hostname"),
-                Collections.<DataPointListener>emptyList(), dataPointFactory);
+                Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 
         System.out.println("Loading Cassandra data");
         loadCassandraData();

--- a/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
@@ -16,6 +16,7 @@
 package org.kairosdb.datastore.h2;
 
 
+import io.opentracing.mock.MockTracer;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -40,6 +41,7 @@ import static org.hamcrest.core.Is.is;
 public class H2DatastoreTest extends DatastoreTestHelper
 {
 	public static final String DB_PATH = "build/h2db_test";
+	private static MockTracer tracer = new MockTracer();
 
 
 	private static void deltree(File directory)
@@ -68,7 +70,7 @@ public class H2DatastoreTest extends DatastoreTestHelper
 
 		s_datastore = new KairosDatastore(new H2Datastore(DB_PATH, dataPointFactory),
 				new QueryQueuingManager(1, "hostname"),
-				Collections.<DataPointListener>emptyList(), dataPointFactory);
+				Collections.<DataPointListener>emptyList(), dataPointFactory, tracer);
 
 		loadData();
 	}


### PR DESCRIPTION
This will help understand the queue up of queries on kairosdb when cassandra takes long to respond. Tested on local docker-compose build for zmon.