### PR TITLE
Hystrix circuit breaker with HystrixCommand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,27 @@
             <version>0.31.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.31.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <version>1.5.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-codahale-metrics-publisher</artifactId>
+            <version>1.5.12</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.codahale.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -28,6 +28,7 @@ import org.kairosdb.core.datastore.*;
 import org.kairosdb.core.exception.DatastoreException;
 import org.kairosdb.datastore.cassandra.cache.RowKeyCache;
 import org.kairosdb.datastore.cassandra.cache.StringKeyCache;
+import org.kairosdb.datastore.cassandra.circuitbreaker.CommandExecute;
 import org.kairosdb.util.KDataOutput;
 import org.kairosdb.util.MemoryMonitor;
 import org.slf4j.Logger;
@@ -343,7 +344,8 @@ public class CassandraDatastore implements Datastore {
             throw new RuntimeException(ex);
         }
 
-        ResultSet rs = m_session.execute(bs);
+        //ResultSet rs = m_session.execute(bs);
+        ResultSet rs = new CommandExecute(m_session, bs).execute();
 
         List<String> ret = new ArrayList<>();
         for (Row r : rs) {
@@ -843,7 +845,8 @@ public class CassandraDatastore implements Datastore {
             bs.setBytes(3, keySerializer.toByteBuffer(startKey));
             bs.setBytes(4, keySerializer.toByteBuffer(endKey));
 
-            ResultSet rs = m_session.execute(bs);
+            //ResultSet rs = m_session.execute(bs);
+            ResultSet rs = new CommandExecute(m_session, bs).execute();
 
             filterAndAddKeys(metricName, filterTags, rs, collector, m_cassandraConfiguration.getMaxRowsForKeysQuery());
 
@@ -853,7 +856,8 @@ public class CassandraDatastore implements Datastore {
             bs.setBytes(1, keySerializer.toByteBuffer(startKey));
             bs.setBytes(2, keySerializer.toByteBuffer(endKey));
 
-            rs = m_session.execute(bs);
+            //rs = m_session.execute(bs);
+            rs = new CommandExecute(m_session, bs).execute();
             filterAndAddKeys(metricName, filterTags, rs, collector, m_cassandraConfiguration.getMaxRowsForKeysQuery());
         } else {
             long calculatedStartTime = calculateRowTimeRead(startTime);
@@ -868,7 +872,8 @@ public class CassandraDatastore implements Datastore {
             bs.setBytes(3, keySerializer.toByteBuffer(startKey));
             bs.setBytes(4, keySerializer.toByteBuffer(endKey));
 
-            ResultSet rs = m_session.execute(bs);
+            //ResultSet rs = m_session.execute(bs);
+            ResultSet rs = new CommandExecute(m_session, bs).execute();
             filterAndAddKeys(metricName, filterTags, rs, collector, m_cassandraConfiguration.getMaxRowsForKeysQuery());
         }
     }
@@ -903,7 +908,8 @@ public class CassandraDatastore implements Datastore {
             bs.setBytes(1, keySerializer.toByteBuffer(startKey));
             bs.setBytes(2, keySerializer.toByteBuffer(endKey));
 
-            ResultSet rs = m_session.execute(bs);
+            //ResultSet rs = m_session.execute(bs);
+            ResultSet rs = new CommandExecute(m_session, bs).execute();
 
             filterAndAddKeys(metricName, filterTags, rs, collector, m_cassandraConfiguration.getMaxRowsForKeysQuery());
 
@@ -913,7 +919,8 @@ public class CassandraDatastore implements Datastore {
             bs.setBytes(1, keySerializer.toByteBuffer(startKey));
             bs.setBytes(2, keySerializer.toByteBuffer(endKey));
 
-            rs = m_session.execute(bs);
+            //rs = m_session.execute(bs);
+            rs = new CommandExecute(m_session, bs).execute();
             filterAndAddKeys(metricName, filterTags, rs, collector, m_cassandraConfiguration.getMaxRowsForKeysQuery());
         } else {
             long calculatedStartTime = calculateRowTimeRead(startTime);
@@ -928,7 +935,8 @@ public class CassandraDatastore implements Datastore {
             bs.setBytes(1, keySerializer.toByteBuffer(startKey));
             bs.setBytes(2, keySerializer.toByteBuffer(endKey));
 
-            ResultSet rs = m_session.execute(bs);
+            //ResultSet rs = m_session.execute(bs);
+            ResultSet rs = new CommandExecute(m_session, bs).execute();
             filterAndAddKeys(metricName, filterTags, rs, collector, m_cassandraConfiguration.getMaxRowsForKeysQuery());
         }
     }

--- a/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/CommandExecute.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/CommandExecute.java
@@ -1,0 +1,139 @@
+package org.kairosdb.datastore.cassandra.circuitbreaker;
+
+import com.datastax.driver.core.*;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Inject;
+import com.netflix.hystrix.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class CommandExecute  extends HystrixCommand<ResultSet>{
+
+    public static final Logger logger = LoggerFactory.getLogger(CommandExecute.class);
+
+    private final Session session;
+    private final BoundStatement bs;
+
+    @Inject
+    private static HystrixProperties configuration;
+
+    private static Setter setter;
+    /**
+     * Peak rps for datapoints_query is 137 rps across 6 kairosdb-read instances
+     * Peak rps per instance = 23
+     * p99 latency of ~1.57 seconds
+     * Thread pool size: 137 * 1.57 = 36 = ~40
+     * @param session Cassandra Session object which executes the query
+     * @param bs Prepared CQL statement
+     */
+    public CommandExecute(Session session, BoundStatement bs){
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("CQLExecute"))
+                .andCommandKey(HystrixCommandKey.Factory.asKey("CQLExecute"))
+                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(1000)
+                        .withFallbackIsolationSemaphoreMaxConcurrentRequests(10)
+                        .withCircuitBreakerRequestVolumeThreshold(20)
+                        .withCircuitBreakerForceOpen(true)
+                        .withFallbackEnabled(false)
+                        .withCircuitBreakerSleepWindowInMilliseconds(5000))
+                .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter()
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)
+                        .withMaximumSize(10))
+                .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey("CQLExecute-ThreadPool")));
+        this.session = session;
+        this.bs = bs;
+    }
+
+    /*@Inject
+    private CommandExecute(Session session, BoundStatement bs, HystrixProperties configuration){
+        this(session, bs, Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("CQLExecute"))
+                .andCommandKey(HystrixCommandKey.Factory.asKey("CQLExecute"))
+                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(configuration.getM_ExecutionTimeoutMillis())
+                        .withFallbackIsolationSemaphoreMaxConcurrentRequests(configuration.getM_FallbackMaxConcurrentRequests())
+                        .withCircuitBreakerRequestVolumeThreshold(configuration.getM_RequestVolumeThreshold())
+                        .withCircuitBreakerSleepWindowInMilliseconds(configuration.getM_SleedWindowMillis()))
+                .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter()
+                        .withAllowMaximumSizeToDivergeFromCoreSize(configuration.isM_AllowDivergeFromCore())
+                        .withMaximumSize(configuration.getM_ThreadPoolMax()))
+                .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey("CQLExecute-ThreadPool")));
+    }
+
+    private CommandExecute(Session session, BoundStatement bs, Setter setter){
+        super(setter);
+        this.session = session;
+        this.bs = bs;
+    }*/
+
+    @Override
+    protected ResultSet run() {
+        return session.execute(bs);
+    }
+
+    @Override
+    protected ResultSet getFallback() {
+        return new ResultSet() {
+            @Override
+            public ColumnDefinitions getColumnDefinitions() {
+                return null;
+            }
+
+            @Override
+            public boolean isExhausted() {
+                return false;
+            }
+
+            @Override
+            public Row one() {
+                return null;
+            }
+
+            @Override
+            public List<Row> all() {
+                List<Row> list = new ArrayList<>();
+                return list;
+            }
+
+            @Override
+            public Iterator<Row> iterator() {
+                return null;
+            }
+
+            @Override
+            public int getAvailableWithoutFetching() {
+                return 0;
+            }
+
+            @Override
+            public boolean isFullyFetched() {
+                return false;
+            }
+
+            @Override
+            public ListenableFuture<ResultSet> fetchMoreResults() {
+                return null;
+            }
+
+            @Override
+            public ExecutionInfo getExecutionInfo() {
+                return null;
+            }
+
+            @Override
+            public List<ExecutionInfo> getAllExecutionInfo() {
+                return null;
+            }
+
+            @Override
+            public boolean wasApplied() {
+                return false;
+            }
+        };
+    }
+
+
+}

--- a/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/HystrixModule.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/HystrixModule.java
@@ -1,0 +1,29 @@
+package org.kairosdb.datastore.cassandra.circuitbreaker;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+import com.netflix.hystrix.contrib.codahalemetricspublisher.HystrixCodaHaleMetricsPublisher;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisher;
+import org.kairosdb.datastore.cassandra.CassandraDatastore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HystrixModule extends AbstractModule{
+    public static final Logger logger = LoggerFactory.getLogger(HystrixModule.class);
+
+    @Override
+    protected void configure(){
+        logger.info("Configured HystrixModule");
+        bind(HystrixProperties.class).in(Singleton.class);
+    }
+
+    @Singleton
+    HystrixMetricsPublisher hystrixMetricsPublisher(MetricRegistry metricRegistry) {
+        HystrixCodaHaleMetricsPublisher publisher = new HystrixCodaHaleMetricsPublisher(metricRegistry);
+        HystrixPlugins.getInstance().registerMetricsPublisher(publisher);
+        logger.info("Hystrix Metrics Publisher configured: {}", publisher.toString());
+        return publisher;
+    }
+}

--- a/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/HystrixProperties.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/HystrixProperties.java
@@ -1,0 +1,88 @@
+package org.kairosdb.datastore.cassandra.circuitbreaker;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+public class HystrixProperties {
+
+    private static final String EXECUTION_TIMEOUT_MILLIS = "hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds";
+    private static final String FALLBACK_MAX_CONCURRENT_REQUESTS = "hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests";
+    private static final String REQUEST_VOLUME_THRESHOLD = "hystrix.command.default.circuitBreaker.requestVolumeThreshold";
+    private static final String SLEEP_WINDOW_MILLIS = "hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds";
+    private static final String THREAD_POOL_MAX = "hystrix.threadpool.default.maximumSize";
+    private static final String ALLOW_DIVERGE_FROM_CORE = "hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize";
+
+    @Inject(optional = true)
+    @Named(EXECUTION_TIMEOUT_MILLIS)
+    private int m_ExecutionTimeoutMillis = 1000;
+
+    @Inject(optional = true)
+    @Named(FALLBACK_MAX_CONCURRENT_REQUESTS)
+    private int m_FallbackMaxConcurrentRequests = 10;
+
+    @Inject(optional = true)
+    @Named(REQUEST_VOLUME_THRESHOLD)
+    private int m_RequestVolumeThreshold = 20;
+
+    @Inject(optional = true)
+    @Named(SLEEP_WINDOW_MILLIS)
+    private int m_SleedWindowMillis = 5000;
+
+    @Inject(optional = true)
+    @Named(THREAD_POOL_MAX)
+    private int m_ThreadPoolMax = 10;
+
+    @Inject(optional = true)
+    @Named(ALLOW_DIVERGE_FROM_CORE)
+    private boolean m_AllowDivergeFromCore = false;
+
+    public HystrixProperties(){}
+
+    public int getM_ExecutionTimeoutMillis() {
+        return m_ExecutionTimeoutMillis;
+    }
+
+    public void setM_ExecutionTimeoutMillis(int m_ExecutionTimeoutMillis) {
+        this.m_ExecutionTimeoutMillis = m_ExecutionTimeoutMillis;
+    }
+
+    public int getM_FallbackMaxConcurrentRequests() {
+        return m_FallbackMaxConcurrentRequests;
+    }
+
+    public void setM_FallbackMaxConcurrentRequests(int m_FallbackMaxConcurrentRequests) {
+        this.m_FallbackMaxConcurrentRequests = m_FallbackMaxConcurrentRequests;
+    }
+
+    public int getM_RequestVolumeThreshold() {
+        return m_RequestVolumeThreshold;
+    }
+
+    public void setM_RequestVolumeThreshold(int m_RequestVolumeThreshold) {
+        this.m_RequestVolumeThreshold = m_RequestVolumeThreshold;
+    }
+
+    public int getM_SleedWindowMillis() {
+        return m_SleedWindowMillis;
+    }
+
+    public void setM_SleedWindowMillis(int m_SleedWindowMillis) {
+        this.m_SleedWindowMillis = m_SleedWindowMillis;
+    }
+
+    public int getM_ThreadPoolMax() {
+        return m_ThreadPoolMax;
+    }
+
+    public void setM_ThreadPoolMax(int m_ThreadPoolMax) {
+        this.m_ThreadPoolMax = m_ThreadPoolMax;
+    }
+
+    public boolean isM_AllowDivergeFromCore() {
+        return m_AllowDivergeFromCore;
+    }
+
+    public void setM_AllowDivergeFromCore(boolean m_AllowDivergeFromCore) {
+        this.m_AllowDivergeFromCore = m_AllowDivergeFromCore;
+    }
+}

--- a/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/Metrics.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/circuitbreaker/Metrics.java
@@ -1,0 +1,15 @@
+package org.kairosdb.datastore.cassandra.circuitbreaker;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisher;
+
+public class Metrics extends HystrixMetricsPublisher {
+
+    private MetricRegistry registry;
+
+    @Inject
+    public Metrics(MetricRegistry registry){
+        this.registry = registry;
+    }
+}


### PR DESCRIPTION
Refers #64 

Executes the CQL read queries wrapped inside HystrixCommand. This is a work in progress. 

## TODO 
Externalize the configurations for HystrixCommand
Capture the metrics for circuit breaker