### PR TITLE
 Make query/tags row key limit same as query one

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -371,7 +371,8 @@ public class CassandraDatastore implements Datastore {
     @Override
     public TagSet queryMetricTags(DatastoreMetricQuery query) {
         TagSetImpl tagSet = new TagSetImpl();
-        Collection<DataPointsRowKey> rowKeys = getKeysForQueryIterator(query, 9999);
+        Collection<DataPointsRowKey> rowKeys =
+                getKeysForQueryIterator(query, m_cassandraConfiguration.getMaxRowsForKeysQuery() + 1);
 
         MemoryMonitor mm = new MemoryMonitor(20);
         for (DataPointsRowKey key : rowKeys) {


### PR DESCRIPTION
`/api/v1/datapoints/query/tags` only returns a limited set of tags values, in our case keys, compared to the full featured query to kairosdb using `/api/v1/datapoints/query`. 