### PR TITLE
Log some non critical queries

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/DatastoreMetricQuery.java
+++ b/src/main/java/org/kairosdb/core/datastore/DatastoreMetricQuery.java
@@ -39,4 +39,8 @@ public interface DatastoreMetricQuery
 	void setQueryUUID(UUID uuid);
 
 	UUID getQueryUUID();
+
+	void setQueryLoggingType(String type);
+
+	String getQueryLoggingType();
 }

--- a/src/main/java/org/kairosdb/core/datastore/DatastoreMetricQuery.java
+++ b/src/main/java/org/kairosdb/core/datastore/DatastoreMetricQuery.java
@@ -36,7 +36,7 @@ public interface DatastoreMetricQuery
 
 	List<QueryPlugin> getPlugins();
 
-	void setCriticalQueryUUID(UUID uuid);
+	void setQueryUUID(UUID uuid);
 
-	UUID getCriticalQueryUUID();
+	UUID getQueryUUID();
 }

--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -442,9 +442,9 @@ public class KairosDatastore {
 
 				if (m_metric.getQueryUUID() != null) {
 					final long endTime = Long.MAX_VALUE == m_metric.getEndTime() ? System.currentTimeMillis() : m_metric.getEndTime();
-					logger.info("critical_query_finished: uuid={} metric={} datapoint_count={} row_count={} start_time={} end_time={} duration={}",
-							m_metric.getQueryUUID(), m_metric.getName(), m_dataPointCount, m_rowCount,
-							m_metric.getStartTime(), endTime, endTime - m_metric.getStartTime());
+					logger.info("{}_query_finished: uuid={} metric={} datapoint_count={} row_count={} start_time={} end_time={} duration={}",
+							m_metric.getQueryLoggingType(), m_metric.getQueryUUID(), m_metric.getName(), m_dataPointCount,
+							m_rowCount, m_metric.getStartTime(), endTime, endTime - m_metric.getStartTime());
 				}
 
                 List<DataPointGroup> queryResults = groupByTypeAndTag(m_metric.getName(),

--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -440,10 +440,10 @@ public class KairosDatastore {
                 span.setTag("datapoint_count", m_dataPointCount);
                 span.setTag("row_count", m_rowCount);
 
-				if (m_metric.getCriticalQueryUUID() != null) {
+				if (m_metric.getQueryUUID() != null) {
 					final long endTime = Long.MAX_VALUE == m_metric.getEndTime() ? System.currentTimeMillis() : m_metric.getEndTime();
 					logger.info("critical_query_finished: uuid={} metric={} datapoint_count={} row_count={} start_time={} end_time={} duration={}",
-							m_metric.getCriticalQueryUUID(), m_metric.getName(), m_dataPointCount, m_rowCount,
+							m_metric.getQueryUUID(), m_metric.getName(), m_dataPointCount, m_rowCount,
 							m_metric.getStartTime(), endTime, endTime - m_metric.getStartTime());
 				}
 

--- a/src/main/java/org/kairosdb/core/datastore/QueryMetric.java
+++ b/src/main/java/org/kairosdb/core/datastore/QueryMetric.java
@@ -41,6 +41,7 @@ public class QueryMetric implements DatastoreMetricQuery
 	private Order order = Order.ASC;
 	private List<QueryPlugin> plugins;
 	private UUID uuid;
+	private String loggingType;
 
 	public QueryMetric(long start_time, int cacheTime, String name)
 	{
@@ -201,6 +202,14 @@ public class QueryMetric implements DatastoreMetricQuery
 	@Override
 	public UUID getQueryUUID() {
 		return uuid;
+	}
+
+	public void setQueryLoggingType(String type) {
+		this.loggingType = type;
+	}
+
+	public String getQueryLoggingType() {
+		return loggingType;
 	}
 
 	public QueryMetric addPlugin(QueryPlugin plugin)

--- a/src/main/java/org/kairosdb/core/datastore/QueryMetric.java
+++ b/src/main/java/org/kairosdb/core/datastore/QueryMetric.java
@@ -194,12 +194,12 @@ public class QueryMetric implements DatastoreMetricQuery
 	}
 
 	@Override
-	public void setCriticalQueryUUID(UUID uuid) {
+	public void setQueryUUID(UUID uuid) {
 		this.uuid = uuid;
 	}
 
 	@Override
-	public UUID getCriticalQueryUUID() {
+	public UUID getQueryUUID() {
 		return uuid;
 	}
 

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -15,6 +15,7 @@
  */
 package org.kairosdb.datastore.cassandra;
 
+import com.datastax.driver.core.*;
 import com.google.common.collect.*;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -15,7 +15,6 @@
  */
 package org.kairosdb.datastore.cassandra;
 
-import com.datastax.driver.core.*;
 import com.google.common.collect.*;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -675,8 +674,8 @@ public class CassandraDatastore implements Datastore {
 
         final boolean isCriticalQuery = rowReadCount > 5000 || filteredRowKeys.size() > 100;
         if (isCriticalQuery) {
-            query.setCriticalQueryUUID(UUID.randomUUID());
-            logCriticalQuery(query, filteredRowKeys, rowReadCount, false, readRowsLimit, index);
+            query.setQueryUUID(UUID.randomUUID());
+            logQuery(query, filteredRowKeys, rowReadCount, false, readRowsLimit, index);
         }
     }
 
@@ -689,20 +688,20 @@ public class CassandraDatastore implements Datastore {
                 span.setTag("max_row_keys", Boolean.TRUE);
             }
 
-            logCriticalQuery(query, filteredRowKeys, rowReadCount, true, limit, index);
+            logQuery(query, filteredRowKeys, rowReadCount, true, limit, index);
             throw new MaxRowKeysForQueryExceededException(errorMessage);
         }
     }
 
-    private static void logCriticalQuery(DatastoreMetricQuery query,
-                                         Collection<DataPointsRowKey> filteredRowKeys,
-                                         int rowReadCount,
-                                         boolean limitExceeded,
-                                         int limit,
-                                         String index) {
+    private static void logQuery(DatastoreMetricQuery query,
+                                 Collection<DataPointsRowKey> filteredRowKeys,
+                                 int rowReadCount,
+                                 boolean limitExceeded,
+                                 int limit,
+                                 String index) {
         final long endTime = Long.MAX_VALUE == query.getEndTime() ? System.currentTimeMillis() : query.getEndTime();
         logger.warn("critical_query: uuid={} metric={} query={} read={} filtered={} start_time={} end_time={} duration={} exceeded={} limit={} index={}",
-                query.getCriticalQueryUUID(), query.getName(), query.getTags(), rowReadCount, filteredRowKeys.size(),
+                query.getQueryUUID(), query.getName(), query.getTags(), rowReadCount, filteredRowKeys.size(),
                 query.getStartTime(), endTime, endTime - query.getStartTime(), limitExceeded, limit, index);
     }
 

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -119,7 +119,8 @@ public class CassandraDatastore implements Datastore {
 
     private CassandraConfiguration m_cassandraConfiguration;
 
-    private final Random randomToLogQueriesOrNot = new Random();
+    private final Random random = new Random();
+    private final int PERCENTAGE_OF_SIMPLE_QUERIES_LOGGED = 10;
 
     @Inject
     public CassandraDatastore(CassandraClient cassandraClient, CassandraConfiguration cassandraConfiguration,
@@ -676,7 +677,7 @@ public class CassandraDatastore implements Datastore {
         }
 
         final boolean isCriticalQuery = rowReadCount > 5000 || filteredRowKeys.size() > 100;
-        if (isCriticalQuery || randomToLogQueriesOrNot.nextInt(100) < 10) {
+        if (isCriticalQuery || random.nextInt(100) < PERCENTAGE_OF_SIMPLE_QUERIES_LOGGED) {
             query.setQueryUUID(UUID.randomUUID());
             query.setQueryLoggingType(isCriticalQuery ? "critical" : "simple");
             logQuery(query, filteredRowKeys, rowReadCount, false, readRowsLimit, index);

--- a/src/test/java/org/kairosdb/datastore/DatastoreMetricQueryImpl.java
+++ b/src/test/java/org/kairosdb/datastore/DatastoreMetricQueryImpl.java
@@ -35,6 +35,7 @@ public class DatastoreMetricQueryImpl implements DatastoreMetricQuery
 	private long m_startTime;
 	private long m_endTime;
 	private UUID uuid;
+	private String loggingType;
 
 
 	public DatastoreMetricQueryImpl(String name, SetMultimap<String, String> tags,
@@ -96,6 +97,14 @@ public class DatastoreMetricQueryImpl implements DatastoreMetricQuery
 	@Override
 	public UUID getQueryUUID() {
 		return uuid;
+	}
+
+	public void setQueryLoggingType(String type) {
+		this.loggingType = type;
+	}
+
+	public String getQueryLoggingType() {
+		return loggingType;
 	}
 
 }

--- a/src/test/java/org/kairosdb/datastore/DatastoreMetricQueryImpl.java
+++ b/src/test/java/org/kairosdb/datastore/DatastoreMetricQueryImpl.java
@@ -89,12 +89,12 @@ public class DatastoreMetricQueryImpl implements DatastoreMetricQuery
 	}
 
 	@Override
-	public void setCriticalQueryUUID(UUID uuid) {
+	public void setQueryUUID(UUID uuid) {
 		this.uuid = uuid;
 	}
 
 	@Override
-	public UUID getCriticalQueryUUID() {
+	public UUID getQueryUUID() {
 		return uuid;
 	}
 


### PR DESCRIPTION
f006da5: remove word `critical` from method naming
We want to log not only critical queries, so that we need to remove this
reference.

b151cfd: add logging type to the `DatastoreMetricQuery`
this allows us to distinguish it in the logs
Also log ~10% of non critical queries 

2bcb68a: fix accidentally removed import

6622826: work on feedback

