### PR TITLE
eagleeye/ZMON#270 move calculated Xmx/Xms before JAVA_OPTS

### DIFF
--- a/src/scripts/kairosdb-env.sh
+++ b/src/scripts/kairosdb-env.sh
@@ -8,4 +8,4 @@ fi
 MEM_TOTAL_KB=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
 MEM_JAVA_KB=$(($MEM_TOTAL_KB * $MEM_JAVA_PERCENT / 100))
 
-JAVA_OPTS="$JAVA_OPTS -Xms${MEM_JAVA_KB}k -Xmx${MEM_JAVA_KB}k -javaagent:/app/lib/jolokia-jvm-1.6.0-agent.jar=port=8778,host=0.0.0.0"
+JAVA_OPTS="-Xms${MEM_JAVA_KB}k -Xmx${MEM_JAVA_KB}k $JAVA_OPTS -javaagent:/app/lib/jolokia-jvm-1.6.0-agent.jar=port=8778,host=0.0.0.0"


### PR DESCRIPTION
move calculated Xmx/Xms before JAVA_OPTS

This allows us to override this calculation in the deployment settings
The reason behind this is that in docker/kubernetes environment using
`/proc/meminfo` will give the whole amount of memory if the host, not
the limit of the docker. Which leads to the quite big heap, without any
garbage collection, and once we reach the limit which is assigned to the
container, the application is OOM killed.