### PR TITLE
Add time bucket to row index tables as partition key

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
@@ -33,17 +33,17 @@ public class CassandraConfiguration {
 	private static final String CASSANDRA_INDEX_TAG_LIST = "kairosdb.datastore.cassandra.index_tag_list";
 	private static final String CASSANDRA_METRIC_INDEX_TAG_LIST = "kairosdb.datastore.cassandra.metric_index_tag_list";
 	private static final String NEW_SPLIT_INDEX_START_TIME_MS = "kairosdb.datastore.cassandra.new_split_index_start_time_ms";
-	private static final String USE_NEW_SPLIT_INDEX_READ = "kairosdb.datastore.cassandra.use_new_split_index_read";
-	private static final String USE_NEW_SPLIT_INDEX_WRITE = "kairosdb.datastore.cassandra.use_new_split_index_write";
+	private static final String USE_TIME_INDEX_READ = "kairosdb.datastore.cassandra.use_time_index_read";
+	private static final String USE_TIME_INDEX_WRITE = "kairosdb.datastore.cassandra.use_time_index_write";
 	private static final String HOST_LIST_PROPERTY = "kairosdb.datastore.cassandra.host_list";
 	private static final String CASSANDRA_PORT = "kairosdb.datastore.cassandra.port";
 	private static final String QUERY_SAMPLING_PERCENTAGE = "kairosdb.datastore.cassandra.query_sampling_percentage";
 	@Inject(optional = true)
-	@Named(USE_NEW_SPLIT_INDEX_READ)
-	private boolean m_useNewSplitIndexRead = false;
+	@Named(USE_TIME_INDEX_READ)
+	private boolean m_useTimeIndexRead = false;
 	@Inject(optional = true)
-	@Named(USE_NEW_SPLIT_INDEX_WRITE)
-	private boolean m_useNewSplitIndexWrite = false;
+	@Named(USE_TIME_INDEX_WRITE)
+	private boolean m_useTimeIndexWrite = false;
 	@Inject(optional = true)
 	@Named(NEW_SPLIT_INDEX_START_TIME_MS)
 	private long m_newSplitIndexStartTimeMs = 0L;
@@ -141,12 +141,12 @@ public class CassandraConfiguration {
 		m_keyspaceName = keyspaceName;
 	}
 
-	public boolean isUseNewSplitIndexRead() {
-		return m_useNewSplitIndexRead;
+	public boolean isUseTimeIndexRead() {
+		return m_useTimeIndexRead;
 	}
 
-	public boolean isUseNewSplitIndexWrite() {
-		return m_useNewSplitIndexWrite;
+	public boolean isUseTimeIndexWrite() {
+		return m_useTimeIndexWrite;
 	}
 
 	public long getNewSplitIndexStartTimeMs() {

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraSetup.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraSetup.java
@@ -29,14 +29,14 @@ public abstract class CassandraSetup {
             "                     'compaction_window_size': '1440'," +
             "                     'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'}";
 
-    public static final String ROW_KEY_SPLIT_INDEX_TABLE = "" +
-            "CREATE TABLE IF NOT EXISTS row_key_split_index (" +
+    public static final String ROW_TIME_KEY_SPLIT_INDEX_TABLE = "" +
+            "CREATE TABLE IF NOT EXISTS row_time_key_split_index (" +
             "  metric_name text," +
+            "  time_bucket bigint," +
             "  tag_name text," +
             "  tag_value text, " +
             "  column1 blob," +
-            "  value blob," +
-            "  PRIMARY KEY ((metric_name, tag_name, tag_value), column1)" +
+            "  PRIMARY KEY ((metric_name, time_bucket, tag_name, tag_value), column1)" +
             ") WITH CLUSTERING ORDER BY (column1 DESC);";
 
     //  The above split index table looks identical, but was not initially made with
@@ -64,6 +64,14 @@ public abstract class CassandraSetup {
             "  column1 blob,\n" +
             "  value blob,\n" +
             "  PRIMARY KEY ((key), column1)\n" +
+            ") WITH CLUSTERING ORDER BY (column1 DESC);";
+
+    public static final String ROW_KEY_TIME_INDEX_TABLE = "" +
+            "CREATE TABLE IF NOT EXISTS row_time_key_index (\n" +
+            "  key blob,\n" +
+            "  time_bucket bigint,\n" +
+            "  column1 blob,\n" +
+            "  PRIMARY KEY ((key, time_bucket), column1)\n" +
             ") WITH CLUSTERING ORDER BY (column1 DESC);";
 
     public static final String STRING_INDEX_TABLE = "" +
@@ -108,9 +116,14 @@ public abstract class CassandraSetup {
                 session.execute(ROW_KEY_INDEX_TABLE);
             }
 
-            if(!tableExists(session, "row_key_split_index")) {
-                logger.info("Creating table 'row_key_split_index' ...");
-                session.execute(ROW_KEY_SPLIT_INDEX_TABLE);
+            if(!tableExists(session, "row_time_key_index")) {
+                logger.info("Creating table 'row_time_key_index' ...");
+                session.execute(ROW_KEY_TIME_INDEX_TABLE);
+            }
+
+            if(!tableExists(session, "row_time_key_split_index")) {
+                logger.info("Creating table 'row_time_key_split_index' ...");
+                session.execute(ROW_TIME_KEY_SPLIT_INDEX_TABLE);
             }
 
             if(!tableExists(session, "row_key_split_index_2")) {


### PR DESCRIPTION
internal ref 388

- create two new tables row_time_key_index and row_time_key_split_index where partition key is (metric_name, time_bucket)
- add configs use_time_index_read and use_time_index_write that enable these tables (off by default)
- remove use_new_split_index_* configs and enable it by default (what we've been using in production)
- remove reference to table row_key_split_index as it is unused