### PR TITLE
Remove ordering in the row_key_index select query

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -71,7 +71,7 @@ public class CassandraDatastore implements Datastore, KairosMetricReporter {
 
     public static final String QUERY_STRING_INDEX = "SELECT column1 FROM string_index WHERE key = ?";
 
-    public static final String QUERY_ROW_KEY_INDEX = "SELECT column1 FROM row_key_index WHERE key = ? AND column1 >= ? and column1 <= ? ORDER BY column1 ASC LIMIT ?";
+    public static final String QUERY_ROW_KEY_INDEX = "SELECT column1 FROM row_key_index WHERE key = ? AND column1 >= ? and column1 <= ? LIMIT ?";
 
     public static final String QUERY_ROW_TIME_KEY_SPLIT_INDEX = "SELECT column1 FROM row_time_key_split_index WHERE metric_name = ? AND tag_name = ? and tag_value IN ? AND column1 >= ? and column1 <= ? AND time_bucket IN ? LIMIT ?";
     public static final String QUERY_ROW_TIME_KEY_INDEX = "SELECT column1 FROM row_time_key_index WHERE key = ? AND column1 >= ? and column1 <= ? AND time_bucket IN ? ORDER BY column1 ASC LIMIT ?";


### PR DESCRIPTION
The clustering order in the table is defined using DESC.  Using the opposite
order in the query adds unnecessary work for Cassandra, especially since we
are enforcing the order later when querying the datapoints.