### PR TITLE
Normalize query span and distance metrics

### DIFF
--- a/src/main/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProvider.java
+++ b/src/main/java/org/kairosdb/core/http/rest/metrics/DefaultQueryMeasurementProvider.java
@@ -118,11 +118,11 @@ public class DefaultQueryMeasurementProvider implements QueryMeasurementProvider
 		measureInternal(query.getStartTime(), Long.MAX_VALUE, histogram, "query_distance_in_days");
 	}
 
-	private void measureInternal(long startTime, long endTime, Histogram histogram, String tag) {
+	private void measureInternal(final long startTime, final long endTime, final Histogram histogram, final String tag) {
 		final long nowUTC = new DateTime(DateTimeZone.UTC).getMillis();
-		startTime = Math.max(startTime, nowUTC - datapoints_ttl * 1000);
-		endTime = Math.min(endTime, nowUTC);
-		final long timeInMillis = endTime - startTime;
+		final long actualStartTime = Math.max(startTime, nowUTC - datapoints_ttl * 1000);
+		final long actualEndTime = Math.min(endTime, nowUTC);
+		final long timeInMillis = actualEndTime - actualStartTime;
 		final long timeInMinutes = timeInMillis / 1000 / 60;
 		histogram.update(timeInMinutes);
 		tracer.activeSpan().setTag(tag, timeInMinutes / 1440);


### PR DESCRIPTION
Normalize kairosdb.queries.span and kairosdb.queries.distance (and corresponding per-query metrics) such that startTime is never earlier than our current TTL and endTime is never later than now.

Dependency:
- [x] `KAIROSDB_DATASTORE_CASSANDRA_DATAPOINT_TTL` needs to be set on read nodes.