### PR TITLE
don't print stacktrace of QueryRejectedException

### DIFF
--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -504,7 +504,7 @@ public class MetricsResource implements KairosMetricReporter {
 			span.log(e.getMessage());
 			return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
 		} catch (QueryRejectedException e) {
-			logger.error("Query was rejected.", e);
+			logger.error("Query to metric {} was rejected.", e.getMetricName());
 			span.log(e.getMessage());
 			return setHeaders(Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(new ErrorResponse(e.getMessage()))).build();
 		} catch (Exception e) {

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -358,7 +358,7 @@ public class MetricsResource implements KairosMetricReporter {
 			System.gc();
 			return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
 		} catch (QueryRejectedException e) {
-			logger.error("Query was rejected.", e);
+			logger.error("Query to metric {} was rejected.", e.getMetricName());
 			span.log(e.getMessage());
 			return setHeaders(Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(new ErrorResponse(e.getMessage()))).build();
 		} catch (Exception e) {

--- a/src/main/java/org/kairosdb/core/tiers/QueryRejectedException.java
+++ b/src/main/java/org/kairosdb/core/tiers/QueryRejectedException.java
@@ -7,4 +7,8 @@ public class QueryRejectedException extends Exception {
         super("Query to metric " + metricName + " was rejected due to tier limitations");
         this.metricName = metricName;
     }
+
+    public String getMetricName() {
+        return metricName;
+    }
 }


### PR DESCRIPTION
Required to avoid spamming logs