### PR TITLE
Index warm up optimization

### DIFF
--- a/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
+++ b/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
@@ -4,7 +4,6 @@ import com.codahale.metrics.health.HealthCheck;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.kairosdb.core.http.rest.MetricsResource;
-import org.kairosdb.datastore.cassandra.CassandraDatastore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,34 +24,35 @@ public class HealthCheckResource {
     private final HealthCheckService m_healthCheckService;
     public static final Logger logger = LoggerFactory.getLogger(HealthCheckResource.class);
 
-    @Inject
-    @Named("kairosdb.health.healthyResponseCode")
-    private int m_healthyResponse = Response.Status.NO_CONTENT.getStatusCode();
+	@Inject
+	@Named("kairosdb.health.healthyResponseCode")
+	private int m_healthyResponse = Response.Status.NO_CONTENT.getStatusCode();
 
 
-    @Inject
-    public HealthCheckResource(HealthCheckService healthCheckService) {
-        m_healthCheckService = checkNotNull(healthCheckService);
-    }
+	@Inject
+	public HealthCheckResource(HealthCheckService healthCheckService)
+	{
+		m_healthCheckService = checkNotNull(healthCheckService);
+	}
 
-    @OPTIONS
-    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-    @Path("check")
-    public Response corsPreflightCheck(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
-                                       @HeaderParam("Access-Control-Request-Method") String requestMethod) {
-        Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
-        return (responseBuilder.build());
-    }
+	@OPTIONS
+	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+	@Path("check")
+	public Response corsPreflightCheck(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
+			@HeaderParam("Access-Control-Request-Method") String requestMethod)
+	{
+		Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
+		return (responseBuilder.build());
+	}
 
-    /**
-     * Health check
-     *
-     * @return 204 if healthy otherwise 500
-     */
-    @GET
-    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-    @Path("check")
-    public Response check() {
+	/**
+	 * Health check
+	 * @return 204 if healthy otherwise 500
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+	@Path("check")
+	public Response check() {
         for (HealthStatus healthCheck : m_healthCheckService.getChecks()) {
             if (DatastoreQueryHealthCheck.NAME.equals(healthCheck.getName())) {
                 continue;
@@ -68,46 +68,51 @@ public class HealthCheckResource {
     }
 
 
-    @OPTIONS
-    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-    @Path("status")
-    public Response corsPreflightStatus(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
-                                        @HeaderParam("Access-Control-Request-Method") String requestMethod) {
-        Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
-        return (responseBuilder.build());
-    }
+	@OPTIONS
+	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+	@Path("status")
+	public Response corsPreflightStatus(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
+			@HeaderParam("Access-Control-Request-Method") String requestMethod)
+	{
+		Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
+		return (responseBuilder.build());
+	}
 
 
-    /**
-     * Returns the status of each health check.
-     *
-     * @return 200
-     */
-    @GET
-    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-    @Path("status")
-    public Response status() {
-        List<String> messages = new ArrayList<String>();
-        for (HealthStatus healthCheck : m_healthCheckService.getChecks()) {
-            HealthCheck.Result result = healthCheck.execute();
-            if (result.isHealthy()) {
-                messages.add(healthCheck.getName() + ": OK");
-            } else {
-                messages.add(healthCheck.getName() + ": FAIL");
-            }
-        }
+	/**
+	 * Returns the status of each health check.
+	 * @return 200
+	 */
+	@GET
+	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+	@Path("status")
+	public Response status()
+	{
+		List<String> messages = new ArrayList<String>();
+		for (HealthStatus healthCheck : m_healthCheckService.getChecks())
+		{
+			HealthCheck.Result result = healthCheck.execute();
+			if (result.isHealthy())
+			{
+				messages.add(healthCheck.getName() + ": OK");
+			}
+			else
+			{
+				messages.add(healthCheck.getName() + ": FAIL");
+			}
+		}
 
-        GenericEntity<List<String>> entity = new GenericEntity<List<String>>(messages) {
-        };
-        return setHeaders(Response.ok(entity)).build();
-    }
+		GenericEntity<List<String>> entity = new GenericEntity<List<String>>(messages) {};
+		return setHeaders(Response.ok(entity)).build();
+	}
 
-    private Response.ResponseBuilder setHeaders(Response.ResponseBuilder responseBuilder) {
-        responseBuilder.header("Access-Control-Allow-Origin", "*");
-        responseBuilder.header("Pragma", "no-cache");
-        responseBuilder.header("Cache-Control", "no-cache");
-        responseBuilder.header("Expires", 0);
+	private Response.ResponseBuilder setHeaders(Response.ResponseBuilder responseBuilder)
+	{
+		responseBuilder.header("Access-Control-Allow-Origin", "*");
+		responseBuilder.header("Pragma", "no-cache");
+		responseBuilder.header("Cache-Control", "no-cache");
+		responseBuilder.header("Expires", 0);
 
-        return (responseBuilder);
-    }
+		return (responseBuilder);
+	}
 }

--- a/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
+++ b/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
@@ -54,7 +54,7 @@ public class HealthCheckResource {
     @Path("check")
     public Response check() {
         for (HealthStatus healthCheck : m_healthCheckService.getChecks()) {
-            if ("Datastore-Query".equals(healthCheck.getName())) {
+            if (DatastoreQueryHealthCheck.NAME.equals(healthCheck.getName())) {
                 continue;
             }
             HealthCheck.Result result = healthCheck.execute();

--- a/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
+++ b/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Path("/api/v1/health")
 public class HealthCheckResource {
     private final HealthCheckService m_healthCheckService;
-    public static final Logger logger = LoggerFactory.getLogger(CassandraDatastore.class);
+    public static final Logger logger = LoggerFactory.getLogger(HealthCheckResource.class);
 
     @Inject
     @Named("kairosdb.health.healthyResponseCode")

--- a/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
+++ b/src/main/java/org/kairosdb/core/health/HealthCheckResource.java
@@ -4,6 +4,9 @@ import com.codahale.metrics.health.HealthCheck;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.kairosdb.core.http.rest.MetricsResource;
+import org.kairosdb.datastore.cassandra.CassandraDatastore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.GenericEntity;
@@ -18,98 +21,93 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Provides REST APIs for health checks
  */
 @Path("/api/v1/health")
-public class HealthCheckResource
-{
-	private final HealthCheckService m_healthCheckService;
+public class HealthCheckResource {
+    private final HealthCheckService m_healthCheckService;
+    public static final Logger logger = LoggerFactory.getLogger(CassandraDatastore.class);
 
-	@Inject
-	@Named("kairosdb.health.healthyResponseCode")
-	private int m_healthyResponse = Response.Status.NO_CONTENT.getStatusCode();
-
-
-	@Inject
-	public HealthCheckResource(HealthCheckService healthCheckService)
-	{
-		m_healthCheckService = checkNotNull(healthCheckService);
-	}
-
-	@OPTIONS
-	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-	@Path("check")
-	public Response corsPreflightCheck(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
-			@HeaderParam("Access-Control-Request-Method") String requestMethod)
-	{
-		Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
-		return (responseBuilder.build());
-	}
-
-	/**
-	 * Health check
-	 * @return 204 if healthy otherwise 500
-	 */
-	@GET
-	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-	@Path("check")
-	public Response check()
-	{
-		for (HealthStatus healthCheck : m_healthCheckService.getChecks())
-		{
-			HealthCheck.Result result = healthCheck.execute();
-			if (!result.isHealthy())
-			{
-				return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR)).build();
-			}
-		}
-
-		return setHeaders(Response.status(m_healthyResponse)).build();
-	}
+    @Inject
+    @Named("kairosdb.health.healthyResponseCode")
+    private int m_healthyResponse = Response.Status.NO_CONTENT.getStatusCode();
 
 
-	@OPTIONS
-	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-	@Path("status")
-	public Response corsPreflightStatus(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
-			@HeaderParam("Access-Control-Request-Method") String requestMethod)
-	{
-		Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
-		return (responseBuilder.build());
-	}
+    @Inject
+    public HealthCheckResource(HealthCheckService healthCheckService) {
+        m_healthCheckService = checkNotNull(healthCheckService);
+    }
+
+    @OPTIONS
+    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+    @Path("check")
+    public Response corsPreflightCheck(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
+                                       @HeaderParam("Access-Control-Request-Method") String requestMethod) {
+        Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
+        return (responseBuilder.build());
+    }
+
+    /**
+     * Health check
+     *
+     * @return 204 if healthy otherwise 500
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+    @Path("check")
+    public Response check() {
+        for (HealthStatus healthCheck : m_healthCheckService.getChecks()) {
+            if ("Datastore-Query".equals(healthCheck.getName())) {
+                continue;
+            }
+            HealthCheck.Result result = healthCheck.execute();
+            if (!result.isHealthy()) {
+                logger.warn("Failed health check: {}. Health check result: {}", healthCheck.getName(), result);
+                return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR)).build();
+            }
+        }
+
+        return setHeaders(Response.status(m_healthyResponse)).build();
+    }
 
 
-	/**
-	 * Returns the status of each health check.
-	 * @return 200
-	 */
-	@GET
-	@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
-	@Path("status")
-	public Response status()
-	{
-		List<String> messages = new ArrayList<String>();
-		for (HealthStatus healthCheck : m_healthCheckService.getChecks())
-		{
-			HealthCheck.Result result = healthCheck.execute();
-			if (result.isHealthy())
-			{
-				messages.add(healthCheck.getName() + ": OK");
-			}
-			else
-			{
-				messages.add(healthCheck.getName() + ": FAIL");
-			}
-		}
+    @OPTIONS
+    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+    @Path("status")
+    public Response corsPreflightStatus(@HeaderParam("Access-Control-Request-Headers") String requestHeaders,
+                                        @HeaderParam("Access-Control-Request-Method") String requestMethod) {
+        Response.ResponseBuilder responseBuilder = MetricsResource.getCorsPreflightResponseBuilder(requestHeaders, requestMethod);
+        return (responseBuilder.build());
+    }
 
-		GenericEntity<List<String>> entity = new GenericEntity<List<String>>(messages) {};
-		return setHeaders(Response.ok(entity)).build();
-	}
 
-	private Response.ResponseBuilder setHeaders(Response.ResponseBuilder responseBuilder)
-	{
-		responseBuilder.header("Access-Control-Allow-Origin", "*");
-		responseBuilder.header("Pragma", "no-cache");
-		responseBuilder.header("Cache-Control", "no-cache");
-		responseBuilder.header("Expires", 0);
+    /**
+     * Returns the status of each health check.
+     *
+     * @return 200
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+    @Path("status")
+    public Response status() {
+        List<String> messages = new ArrayList<String>();
+        for (HealthStatus healthCheck : m_healthCheckService.getChecks()) {
+            HealthCheck.Result result = healthCheck.execute();
+            if (result.isHealthy()) {
+                messages.add(healthCheck.getName() + ": OK");
+            } else {
+                messages.add(healthCheck.getName() + ": FAIL");
+            }
+        }
 
-		return (responseBuilder);
-	}
+        GenericEntity<List<String>> entity = new GenericEntity<List<String>>(messages) {
+        };
+        return setHeaders(Response.ok(entity)).build();
+    }
+
+    private Response.ResponseBuilder setHeaders(Response.ResponseBuilder responseBuilder) {
+        responseBuilder.header("Access-Control-Allow-Origin", "*");
+        responseBuilder.header("Pragma", "no-cache");
+        responseBuilder.header("Cache-Control", "no-cache");
+        responseBuilder.header("Expires", 0);
+
+        return (responseBuilder);
+    }
 }

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -136,6 +136,7 @@ public class CassandraDatastore implements Datastore, KairosMetricReporter {
     private final Random random = new Random();
 
     private final AtomicLong m_rowKeyIndexRowsInserted = new AtomicLong();
+    private final AtomicLong m_nextRowKeyIndexRowsInserted = new AtomicLong();
     private final AtomicLong m_rowKeySplitIndexRowsInserted = new AtomicLong();
     private final AtomicLong m_readRowLimitExceededCount = new AtomicLong();
     private final AtomicLong m_filteredRowLimitExceededCount = new AtomicLong();
@@ -306,7 +307,9 @@ public class CassandraDatastore implements Datastore, KairosMetricReporter {
                         tagNameCache.put(tagName);
                     }
                 }
-            } else if (m_cacheWarmingUpConfiguration.isEnabled()) {
+            }
+
+            if (m_cacheWarmingUpConfiguration.isEnabled()) {
                 long now = System.currentTimeMillis();
                 int interval = m_cacheWarmingUpConfiguration.getHeatingIntervalMinutes();
                 int rowSize = m_cacheWarmingUpConfiguration.getRowIntervalMinutes();
@@ -317,7 +320,7 @@ public class CassandraDatastore implements Datastore, KairosMetricReporter {
                     if (!rowKeyCache.isKnown(serializeNextKey)) {
                         storeRowKeyReverseLookups(metricName, nextRowTime, serializeNextKey, rowKeyTtl, tags);
                         rowKeyCache.put(serializeNextKey);
-                        logger.warn("next_bucket_row_key={}", nextBucketRowKey);
+                        m_nextRowKeyIndexRowsInserted.incrementAndGet();
                     }
                 }
             }
@@ -584,6 +587,7 @@ public class CassandraDatastore implements Datastore, KairosMetricReporter {
     public List<DataPointSet> getMetrics(long now) {
         return Arrays.asList(
                 getDataPointSet(now, m_rowKeyIndexRowsInserted, "kairosdb.inserted.row_key_index"),
+                getDataPointSet(now, m_nextRowKeyIndexRowsInserted, "kairosdb.inserted.next_row_key_index"),
                 getDataPointSet(now, m_rowKeySplitIndexRowsInserted, "kairosdb.inserted.row_key_split_index"),
                 getDataPointSet(now, m_readRowLimitExceededCount, "kairosdb.limits.read_rows_exceeded"),
                 getDataPointSet(now, m_filteredRowLimitExceededCount, "kairosdb.limits.filtered_rows_exceeded")

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -313,7 +313,7 @@ public class CassandraDatastore implements Datastore, KairosMetricReporter {
                 long now = System.currentTimeMillis();
                 int interval = m_cacheWarmingUpConfiguration.getHeatingIntervalMinutes();
                 int rowSize = m_cacheWarmingUpConfiguration.getRowIntervalMinutes();
-                final long nextRowTime = rowTime + m_rowWidthWrite;
+                final long nextRowTime = calculateRowTimeWrite(dataPoint.getTimestamp() + m_rowWidthWrite);
                 final DataPointsRowKey nextBucketRowKey = new DataPointsRowKey(metricName, nextRowTime, dataPoint.getDataStoreDataType(), tags);
                 if (m_cacheWarmingUpLogic.isWarmingUpNeeded(nextBucketRowKey.hashCode(), now, nextRowTime, interval, rowSize)) {
                     final ByteBuffer serializeNextKey = DATA_POINTS_ROW_KEY_SERIALIZER.toByteBuffer(nextBucketRowKey);

--- a/src/test/java/org/kairosdb/core/health/HealthCheckResourceTest.java
+++ b/src/test/java/org/kairosdb/core/health/HealthCheckResourceTest.java
@@ -46,12 +46,12 @@ public class HealthCheckResourceTest
 	}
 
 	@Test
-	public void testCheckUnHealthy() throws DatastoreException
+	public void testCheckIgnoreDataStoreUnHealthy() throws DatastoreException
 	{
 		when(datastore.getMetricNames()).thenThrow(new DatastoreException("Error"));
 		Response response = resourceService.check();
 
-		assertThat(response.getStatus(), equalTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+		assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
 	}
 
 	@Test


### PR DESCRIPTION
- [x] Remove condition to not ingest future key together with current key
- [x] Add a metric to monitor number of ingestions of future keys
- [x] Adjust a future time bucket calculation to be exactly the same as for the current time bucket
- [x] Ignore Cassandra Datastore unhealthy check
- [x] Log in case of JVM deadlock threads unhealthy check

Tested on staging: https://grafana-staging.zalando.net/d/0Tw3ROxWz/kdb-staging-dashboard?orgId=1&from=now-1h&to=now&refresh=1m
