### PR TITLE
stop storing full key in AbstractByteBufferCache

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/cache/AbstractByteBufferCache.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/cache/AbstractByteBufferCache.java
@@ -22,7 +22,7 @@ public abstract class AbstractByteBufferCache {
     private static final int XX_SEED = 0xCAFEBABE;
 
     @VisibleForTesting
-    final Cache<BigInteger, Object> internalCache;
+    private final Cache<BigInteger, Boolean> internalCache;
 
     @VisibleForTesting
     AbstractByteBufferCache(final CacheMetricsProvider cacheMetricsProvider,
@@ -50,7 +50,7 @@ public abstract class AbstractByteBufferCache {
 
     public void put(@Nonnull final ByteBuffer key) {
         final BigInteger hash = doubleHash(key);
-        this.internalCache.put(hash, key);
+        this.internalCache.put(hash, Boolean.TRUE);
     }
 
     public boolean isKnown(final ByteBuffer key) {


### PR DESCRIPTION
Currently, `AbstractByteBufferCache` uses Caffeine to record known keys. It uses `Cache<BigInteger, Object>`, which actually is `Cache<BigInteger, ByteBuffer>`, since value is always ByteBuffer.

Problem

When investigating occasional crashes of kairosdb, we noticed that in virtually all cases the server's memory was running low. Furthermore, we see that increase in memory usage correlates with row key cache (largest use of `AbstractByteBufferCache`). On a server with ~140GB RAM we seem to be able to store no more than 100 million items, which suggests that each item in the cache takes up about 1KB. We need to be able to store 100 million items (and more) as the demands on the system grow, especially after #132 which introduced cache warmup and causes row key cache item count to double (and if a new node comes up close to warmup period - tripple).

Solution

This commit changes what we store in the cache. Key stays the same - a BigInteger that stores 2 long values, which roughly needs 16 bytes (plus object internals). Value changes to a boolean, where we use a singleton `Boolean.TRUE`, so we store only reference to it. Internal storage mechanisms of Caffeine cache itself have not been changed.

Internals of this class (specifically the cache itself) do not leak to subclasses, and to keep it this way `internalCache` was made private.