### PR TITLE
increase the time CacheFileCleaner waits before deleting old cache dir

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -153,8 +153,8 @@ public class KairosDatastore {
 
 		if (wait) {
 			try {
-				logger.warn("Sleep for 1 minute");
-				Thread.sleep(60000);
+				logger.warn("Sleep for 10 minutes, to make sure that all read requests using old cache dir are finished");
+				Thread.sleep(10*60*1000);
 			} catch (InterruptedException e) {
 				logger.error("Sleep interrupted:", e);
 			}

--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -411,7 +411,7 @@ public class KairosDatastore implements KairosMetricReporter {
 		int misses = m_readCacheMiss.get();
 
 		dpsHit.addDataPoint(m_longDataPointFactory.createDataPoint(now, hits));
-		dpsHit.addDataPoint(m_longDataPointFactory.createDataPoint(now, misses));
+		dpsMiss.addDataPoint(m_longDataPointFactory.createDataPoint(now, misses));
 
 		dpsHit.addTag("host", hostName);
 		dpsHit.addTag("artifact_version", m_artifactVersion);


### PR DESCRIPTION
from 1 minute to 10 minutes

We saw from logs that sometimes CacheFileCleaner cannot delete an old folder:

`ERROR [KairosDatastore.java:146] - Unable to delete directory '/tmp/kairos_cache/1577692800000'`

This means that this folder will never be deleted, as there is no retry logic. Ultimately this will cause disk space leak.


Additionally:
- add metrics for cache hits and misses on read
- set span tag "cache" to false on cache miss