### PR TITLE
Reduce delay before deleting the cache

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -193,8 +193,8 @@ public class KairosDatastore implements KairosMetricReporter {
 
         if (wait) {
             try {
-                logger.warn("Sleep for 10 minutes, to make sure that all read requests using old cache dir are finished");
-                Thread.sleep(10 * 60 * 1000);
+                logger.warn("Sleep for 1 minute and 10 seconds, cause the lifespan of cache file is one minute");
+                Thread.sleep(70 * 1000);
             } catch (InterruptedException e) {
                 logger.error("Sleep interrupted:", e);
             }


### PR DESCRIPTION
Set sleep to 1 minute and 10 seconds, cause the lifespan of the cache file is one minute, so we are definitely won't delete files in use.
 
In a separate PR, the interval of cleaning the cache is reduced to 5 minutes.